### PR TITLE
fixing crashes for headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ panda.plot(q=panda.qr)
 We will load a model of the Franka-Emika Panda robot and make it travel towards a goal pose defined by the variable Tep.
 
 ```python
-import roboticstoolbox as rtb
+from roboticstoolbox.backends.swift import Swift
 import spatialmath as sm
 import numpy as np
 
 # Make and instance of the Swift simulator and open it
-env = rtb.backends.Swift()
-env.launch()
+env = Swift()
+env.launch(realtime=True)
 
 # Make a panda model and set its joint angles to the ready joint configuration
 panda = rtb.models.Panda()

--- a/swift/Swift.py
+++ b/swift/Swift.py
@@ -74,7 +74,7 @@ class Swift:
 
         self._init()
 
-    def _init(self):
+    def _init(self, headless=False):
         """
         A private initialization method to make relaunching easy
         """
@@ -98,7 +98,7 @@ class Swift:
         # Element dict which holds the callback functions for form updates
         self.elements = {}
 
-        self.headless = False
+        self.headless = headless
         self.rendering = True
         self._notrenderperiod = 1
         self.recording = False
@@ -167,7 +167,7 @@ class Swift:
         self._run_thread = False
         if not self.headless:
             self.socket.join(1)
-        if not self._dev:
+        if not self._dev and not self.headless:
             self.server.join(1)
 
     def step(self, dt=0.05, render=True):
@@ -271,10 +271,12 @@ class Swift:
         ``launch()``.
 
         """
+        if not self.headless:
+            self._send_socket("close", "0", False)
+            self._stop_threads()
 
-        self._send_socket("close", "0", False)
-        self._stop_threads()
-        self._init()
+        self._init(headless=self.headless)
+
         self.launch(
             realtime=self.realtime,
             headless=self.headless,


### PR DESCRIPTION
Some issues currently exist when running Swift headless, specifically the interaction with restarting the environment, as _init will reset the headless flag and try to join the server, which only exists in non-headless mode. 

This PR should fix these issues