### PR TITLE
bugfix - do not update the deleted items on env.step()

### DIFF
--- a/swift/Swift.py
+++ b/swift/Swift.py
@@ -224,7 +224,9 @@ class Swift:
 
         # Update world transform of objects
         for obj in self.swift_objects:
-            obj._propogate_scene_tree()
+            # check if object is deleted
+            if obj is not None:
+                obj._propogate_scene_tree()
 
         # Adjust sim time
         self.sim_time += dt


### PR DESCRIPTION
Hi @jhavl,

This is a quick PR. I've stumbled upon a problem when I add a mesh file to the environment and remove it later on.

```pyhton
...
env.add(poly_mesh)
...
env.remove(poly_mesh)
...
env.step()
```

basically the for loop inisde the `env.step()` does not check if the object has been deleted or not. So I've added it. 
With this change the above code work properly. 
