### PR TITLE
Remove leading slash for paths to be retrieved

### DIFF
--- a/swift/SwiftRoute.py
+++ b/swift/SwiftRoute.py
@@ -387,7 +387,7 @@ class SwiftServer:
                     self.path = "index.html"
                 elif self.path.startswith("/retrieve/"):
                     # print(f"Retrieving file: {self.path[10:]}")
-                    self.path = urllib.parse.unquote(self.path[9:])
+                    self.path = urllib.parse.unquote(self.path[10:])
                     self.send_file_via_real_path()
                     return
 


### PR DESCRIPTION
The leading slash breaks windows compatibility as paths starting with `/C:/` can't be resolved on windows, as mentioned here https://github.com/jhavl/swift/commit/f6c8cdea481b713540b5889c0c8c125ca0cc3ac0#r116060265. Removing this leading slash on Linux does not change the behavior, paths like `/home/...` and `//home/...` can both be resolved.

Here's the output of the commented `print` call for `self.path[10:]` on Linux:
```
Retrieving file: /home/<redacted>/meshes/link_base_1.STL
```
And here's the output of the commented `print` call for `self.path[9:]`:
```
Retrieving file: //home/<redacted>/meshes/link_base_1.STL
```

Is there any reason to keep this for *nix platforms? If yes I'd be happy to add a conditional parsing.
