### PR TITLE
Don't _propogate_scene_tree() for None objects

### DIFF
--- a/swift/Swift.py
+++ b/swift/Swift.py
@@ -224,7 +224,8 @@ class Swift:
 
         # Update world transform of objects
         for obj in self.swift_objects:
-            obj._propogate_scene_tree()
+            if obj is not None:
+                obj._propogate_scene_tree()
 
         # Adjust sim time
         self.sim_time += dt


### PR DESCRIPTION
When an object is removed, it is set to None, and thus doesn't have the _propogate_scene_tree() method.

Example of what is not wokring now
``` python
from swift import Swift
from spatialgeometry import Sphere
from spatialmath import SE3

backend = Swift()
backend.launch()
shp1 = Sphere(radius=1, base=SE3(0, 0, 0))
backend.add(shp1)
backend.remove(shp1)
backend.step()
```
```bash
File [swift/swift/Swift.py:227], in Swift.step(self, dt, render)
    [225]# Update world transform of objects
    [226]for obj in self.swift_objects:
--> [227]     obj._propogate_scene_tree()
    [229]# Adjust sim time
    [230]self.sim_time += dt

AttributeError: 'NoneType' object has no attribute '_propogate_scene_tree'
```