### PR TITLE
websockets serve needs to run async to work

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -5,7 +5,10 @@ from queue import Queue
 outq = Queue()
 inq = Queue()
 
-start_servers(outq, inq)
+def stop_servers():
+    return False
+
+start_servers(outq, inq, stop_servers)
 
 while 1:
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Peter Corke", email = "rvc@petercorke.com" },
 ]
 
-dependencies = ["numpy>=1.17.4", "spatialgeometry>=1.0.0", "websockets"]
+dependencies = ["numpy>=2.0", "spatialgeometry>=1.0.0", "websockets"]
 
 license = { file = "LICENSE" }
 
@@ -76,7 +76,7 @@ nb = ["ipython", "notebook"]
 
 [build-system]
 
-requires = ["setuptools", "oldest-supported-numpy"]
+requires = ["setuptools", "numpy>=2.0"]
 
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Updated the starting of the websockets async server, so that the call to serve is also async.
The (newer?) websockets version does not expect a path as argument for the serve function, so that was removed as well.

I also encountered the bug of a not merged pull request (Windows 11 path starting with a '/' like "/C:/Users/...") so I updated this as well.