### PR TITLE
fix: correct black's target-version key in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ packages = ["swift"]
 [tool.black]
 
 line-length = 88
-target_version = ['py37']
+target-version = ['py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$'
 exclude = '''
 


### PR DESCRIPTION
\`target_version\` (underscore) isn't a key black recognises -- its actual config key is \`target-version\` (hyphen), so this was silently ignored and black fell back to auto-detecting the target version from syntax instead of using the configured value. Also bumps the target set to match \`requires-python\` (>=3.10).