### PR TITLE
docs: correct stale comment in SwiftRoute.py's /retrieve/ handler

### DIFF
--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -230,7 +230,7 @@ class SwiftServer:
                 elif self.path == "/?" + str(socket_port):
                     self.path = "index.html"
                 elif self.path.startswith("/retrieve/"):
-                    # print(f"Retrieving file: {self.path[10:]}")
+                    # print(f"Retrieving file: {self.path[9:]}")
                     self.path = urllib.parse.unquote(self.path[9:])
                     self.send_file_via_real_path()
                     return


### PR DESCRIPTION
**Update:** the original version of this PR was wrong and has been corrected in place (force-pushed) — see the commit message for the full explanation. Leaving the history here rather than opening a fresh PR, in the interest of not hiding the mistake.

Original claim was that \`self.path[9:]\` should be \`self.path[10:]\` when stripping the \`/retrieve/\` prefix. That's backwards for the *current* frontend: \`shapes.js\` builds the request URL as \`"/retrieve" + encodeURI(filename)\` with no trailing slash in that literal, so an absolute filename's own leading \`/\` is what completes the \`/retrieve/\` prefix match, landing at index 9. \`self.path[9:]\` (the original code) preserves that leading slash and is correct; \`self.path[10:]\` strips it and breaks every absolute-path mesh lookup on Mac/Linux -- confirmed both with a real HTTP request against a running server and by hand in a real browser loading a real robot's meshes.

Community PRs #52 and #58 made the same \`[9:]\`→\`[10:]\` change I mistakenly copied here, but against the pre-rebuild frontend, which likely built this URL differently (with an explicit trailing slash, genuinely causing a double-slash bug there). Their fix doesn't carry over to the current URL construction, and I ported it without re-verifying that against current code -- that's on me.

The only real change left in this PR is a one-line comment fix: the comment directly above this code already said \`self.path[10:]\`, and was simply stale/wrong independent of any of this.

Stacked on #68 (timeout-bugs).