### PR TITLE
fix: honour realtime_speed in headless mode

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -259,6 +259,9 @@ class Swift:
             self.realtime_speed = float(realtime)
         self.headless = headless
         self.axes = axes
+        # Anchors realtime_speed's pacing clock (see step()) -- needed in
+        # headless mode too, not just for rendering.
+        self.last_time = time.time()
 
         if not self.headless:
             # A flag for our threads to monitor for when to quit
@@ -269,7 +272,6 @@ class Swift:
                 self._servers_running,
                 browser=browser,
             )
-            self.last_time = time.time()
 
             # The realtime, render and pause buttons -- added after the
             # browser has connected, since sending them any earlier would
@@ -345,24 +347,27 @@ class Swift:
             if isinstance(obj, Shape):
                 obj._propogate_scene_tree()
 
+        if self.realtime_speed:
+            # Delay progress if we're running too quickly for the target
+            # speed -- 0.5x should take twice as long (wall clock) per dt
+            # of simulated time as 1x, 0.25x four times as long, etc.
+            # Applies in headless mode too -- realtime pacing and
+            # rendering are independent concerns; only the rendering
+            # itself needs a live browser tab to skip.
+            time_taken = time.time() - self.last_time
+            diff = (dt * self._skipped) / self.realtime_speed - time_taken
+            self._skipped = 1
+
+            if diff > 0:
+                time.sleep(diff)
+
+            self.last_time = time.time()
+
         if not self.headless:
 
             if render and self.rendering:
 
-                if self.realtime_speed:
-                    # Delay progress if we're running too quickly for the
-                    # target speed -- 0.5x should take twice as long (wall
-                    # clock) per dt of simulated time as 1x, 0.25x four
-                    # times as long, etc.
-                    time_taken = time.time() - self.last_time
-                    diff = (dt * self._skipped) / self.realtime_speed - time_taken
-                    self._skipped = 1
-
-                    if diff > 0:
-                        time.sleep(diff)
-
-                    self.last_time = time.time()
-                elif (time.time() - self._laststep) < self._period:
+                if not self.realtime_speed and (time.time() - self._laststep) < self._period:
                     # Only render at 60 FPS
                     self._skipped += 1
                     return

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -230,7 +230,7 @@ class SwiftServer:
                 elif self.path == "/?" + str(socket_port):
                     self.path = "index.html"
                 elif self.path.startswith("/retrieve/"):
-                    # print(f"Retrieving file: {self.path[10:]}")
+                    # print(f"Retrieving file: {self.path[9:]}")
                     self.path = urllib.parse.unquote(self.path[9:])
                     self.send_file_via_real_path()
                     return

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -253,3 +253,22 @@ def test_speed_control_maps_select_index_to_speed_multiplier():
     env._time_control(0)
     assert env.realtime_speed is None
     browser.stop()
+
+
+def test_headless_realtime_still_paces_steps():
+    # Regression test for jhavl/swift#60: realtime_speed's pacing sleep
+    # used to sit entirely inside `if not self.headless`, so headless
+    # runs ignored it and ran flat-out regardless of realtime=True.
+    import time
+
+    env = make_env()
+    env.headless = True
+    env.realtime_speed = 1.0
+    env.last_time = time.time()
+
+    t0 = time.time()
+    for _ in range(3):
+        env.step(0.05)
+    elapsed = time.time() - t0
+
+    assert elapsed >= 0.1, "headless step() did not pace to realtime_speed"


### PR DESCRIPTION
step()'s realtime pacing (the \`time.sleep()\` that keeps a run from going faster than \`realtime_speed\`) sat entirely inside \`if not self.headless\`, so \`launch(realtime=True, headless=True)\` ran flat-out regardless -- reported in #60. Pacing and rendering are independent concerns; only rendering needs a live browser tab to skip.

Also fixes a latent \`AttributeError\` this surfaced: \`self.last_time\` (the pacing clock's anchor) was only ever set on the non-headless \`launch()\` path, so a headless run reaching this code would have crashed the first time it actually got exercised.

Closes #60.

Stacked on #69 (fix/retrieve-path-offset).