### PR TITLE
feat: add launch(ground_opacity=) control

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -169,6 +169,17 @@ class Swift:
         # matches real time, 0.5 is half speed (slow motion), etc.
         self.realtime_speed = None
         self.axes = True
+        # How long hold() keeps waiting after the browser disconnects
+        # before giving up -- see launch()'s timeout= and hold(). None
+        # means wait forever (the old behaviour).
+        self._hold_timeout = 5
+        # How long the *browser tab* waits after losing its connection to
+        # this Python process before closing itself -- see launch()'s
+        # browser_timeout=. None means never auto-close. Independent of
+        # _hold_timeout: this fires from the browser side, so it still
+        # applies even if this process was killed outright rather than
+        # exiting through hold().
+        self._browser_timeout = 5
 
     @property
     def rate(self):
@@ -220,6 +231,8 @@ class Swift:
         rate: int = 60,
         browser: str | None = None,
         axes: bool = True,
+        timeout: float | None = 5,
+        browser_timeout: float | None = 5,
         **kwargs,
     ):
         """
@@ -227,6 +240,14 @@ class Swift:
 
         ``env = launch(args)`` create a 3D scene in a running Swift instance as
         defined by args, and returns a reference to the backend.
+
+        ``timeout`` and ``browser_timeout`` cover two different halves of
+        the same disconnect: ``timeout`` is how long this Python process
+        (specifically :meth:`hold`) keeps waiting once it notices the
+        browser is gone; ``browser_timeout`` is how long the browser tab
+        itself waits once it notices *this process* is gone before
+        closing itself. Neither one can observe the other's side of a
+        disconnect directly, so both exist and are set independently.
 
         :param realtime: Force the simulator to display no faster than real
             time, note that it may still run slower due to complexity.
@@ -248,11 +269,29 @@ class Swift:
         :param axes: Show the world-frame axes helper at the origin,
             defaults to True
         :type axes: bool
+        :param timeout: how long :meth:`hold` keeps waiting, in seconds,
+            after the browser tab disconnects before giving up and
+            returning. ``None`` means wait indefinitely (the pre-2.1
+            behaviour), defaults to 5
+        :type timeout: float | None
+        :param browser_timeout: how long the *browser tab* waits, in
+            seconds, after losing its connection to this process before
+            closing itself. ``None`` means never auto-close, defaults to
+            5. Independent of ``timeout`` -- this fires browser-side, so
+            it still applies if this process is killed outright rather
+            than exiting through :meth:`hold`. Only takes effect on a
+            tab the browser considers script-opened; on a normally
+            user-opened tab (the common case) ``window.close()`` is a
+            silent no-op and the tab is left showing a "Disconnected"
+            banner instead.
+        :type browser_timeout: float | None
 
         """
 
         self.browser = browser
         self.rate = rate
+        self._hold_timeout = timeout
+        self._browser_timeout = browser_timeout
         if isinstance(realtime, bool):
             self.realtime_speed = 1.0 if realtime else None
         else:
@@ -280,6 +319,8 @@ class Swift:
 
             if not self.axes:
                 self._send_socket("axes", False, expected=False)
+
+            self._send_socket("browser_timeout", self._browser_timeout, expected=False)
 
     def _servers_running(self):
         return self._run_thread
@@ -420,6 +461,8 @@ class Swift:
 
         prior_speed = self.realtime_speed
         prior_axes = self.axes
+        prior_timeout = self._hold_timeout
+        prior_browser_timeout = self._browser_timeout
 
         self._send_socket("close", "0", False)
         self._stop_threads()
@@ -429,6 +472,8 @@ class Swift:
             rate=self.rate,
             browser=self.browser,
             axes=prior_axes,
+            timeout=prior_timeout,
+            browser_timeout=prior_browser_timeout,
         )
         self.realtime_speed = prior_speed
 
@@ -715,16 +760,48 @@ class Swift:
         if not self.headless:
             self._send_socket(code, idd)
 
-    def hold(self):  # pragma: no cover
+    def hold(self, timeout: float | None = None):
         """
-        hold() keeps the browser tab open i.e. stops the browser tab from
-        closing once the main script has finished.
+        Block until the browser disconnects (or forever)
 
+        Meant to sit at the end of a script: once your simulation loop
+        finishes, the script would otherwise exit immediately, killing
+        this process and disconnecting the browser tab mid-view. ``hold()``
+        keeps this process (and so the tab) alive so you can keep looking
+        at the final scene.
+
+        Returns once the browser has been disconnected (tab closed,
+        crashed, ...) for longer than ``timeout``, rather than holding
+        forever regardless of whether there's still a tab to hold open for
+        -- see :meth:`launch`'s ``timeout=``, which sets the default this
+        method uses when called with no argument.
+
+        :param timeout: seconds to keep waiting after the browser
+            disconnects before giving up and returning; defaults to
+            whatever :meth:`launch` was given (itself 5 by default).
+            ``None`` waits forever, matching the pre-2.1 behaviour.
+        :type timeout: float | None
         """
+
+        if timeout is None:
+            timeout = self._hold_timeout
+
+        disconnected_since = None
 
         try:
             while True:
                 time.sleep(1)
+
+                if self.headless:
+                    continue
+
+                if len(self.socket.USERS) == 0:
+                    if disconnected_since is None:
+                        disconnected_since = time.time()
+                    elif timeout is not None and time.time() - disconnected_since > timeout:
+                        return
+                else:
+                    disconnected_since = None
         except KeyboardInterrupt:
             self.close()
             raise

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -259,6 +259,9 @@ class Swift:
             self.realtime_speed = float(realtime)
         self.headless = headless
         self.axes = axes
+        # Anchors realtime_speed's pacing clock (see step()) -- needed in
+        # headless mode too, not just for rendering.
+        self.last_time = time.time()
 
         if not self.headless:
             # A flag for our threads to monitor for when to quit
@@ -269,7 +272,6 @@ class Swift:
                 self._servers_running,
                 browser=browser,
             )
-            self.last_time = time.time()
 
             # The realtime, render and pause buttons -- added after the
             # browser has connected, since sending them any earlier would
@@ -345,24 +347,27 @@ class Swift:
             if isinstance(obj, Shape):
                 obj._propogate_scene_tree()
 
+        if self.realtime_speed:
+            # Delay progress if we're running too quickly for the target
+            # speed -- 0.5x should take twice as long (wall clock) per dt
+            # of simulated time as 1x, 0.25x four times as long, etc.
+            # Applies in headless mode too -- realtime pacing and
+            # rendering are independent concerns; only the rendering
+            # itself needs a live browser tab to skip.
+            time_taken = time.time() - self.last_time
+            diff = (dt * self._skipped) / self.realtime_speed - time_taken
+            self._skipped = 1
+
+            if diff > 0:
+                time.sleep(diff)
+
+            self.last_time = time.time()
+
         if not self.headless:
 
             if render and self.rendering:
 
-                if self.realtime_speed:
-                    # Delay progress if we're running too quickly for the
-                    # target speed -- 0.5x should take twice as long (wall
-                    # clock) per dt of simulated time as 1x, 0.25x four
-                    # times as long, etc.
-                    time_taken = time.time() - self.last_time
-                    diff = (dt * self._skipped) / self.realtime_speed - time_taken
-                    self._skipped = 1
-
-                    if diff > 0:
-                        time.sleep(diff)
-
-                    self.last_time = time.time()
-                elif (time.time() - self._laststep) < self._period:
+                if not self.realtime_speed and (time.time() - self._laststep) < self._period:
                     # Only render at 60 FPS
                     self._skipped += 1
                     return

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -169,6 +169,7 @@ class Swift:
         # matches real time, 0.5 is half speed (slow motion), etc.
         self.realtime_speed = None
         self.axes = True
+        self.ground_opacity = 1.0
         # How long hold() keeps waiting after the browser disconnects
         # before giving up -- see launch()'s timeout= and hold(). None
         # means wait forever (the old behaviour).
@@ -231,6 +232,7 @@ class Swift:
         rate: int = 60,
         browser: str | None = None,
         axes: bool = True,
+        ground_opacity: float = 1.0,
         timeout: float | None = 5,
         browser_timeout: float | None = 5,
         **kwargs,
@@ -269,6 +271,9 @@ class Swift:
         :param axes: Show the world-frame axes helper at the origin,
             defaults to True
         :type axes: bool
+        :param ground_opacity: Opacity of the ground plane, from 0
+            (invisible) to 1 (opaque), defaults to 1
+        :type ground_opacity: float
         :param timeout: how long :meth:`hold` keeps waiting, in seconds,
             after the browser tab disconnects before giving up and
             returning. ``None`` means wait indefinitely (the pre-2.1
@@ -298,6 +303,7 @@ class Swift:
             self.realtime_speed = float(realtime)
         self.headless = headless
         self.axes = axes
+        self.ground_opacity = ground_opacity
         # Anchors realtime_speed's pacing clock (see step()) -- needed in
         # headless mode too, not just for rendering.
         self.last_time = time.time()
@@ -319,6 +325,9 @@ class Swift:
 
             if not self.axes:
                 self._send_socket("axes", False, expected=False)
+
+            if self.ground_opacity != 1.0:
+                self._send_socket("ground_opacity", self.ground_opacity, expected=False)
 
             self._send_socket("browser_timeout", self._browser_timeout, expected=False)
 

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -230,7 +230,7 @@ class SwiftServer:
                 elif self.path == "/?" + str(socket_port):
                     self.path = "index.html"
                 elif self.path.startswith("/retrieve/"):
-                    # print(f"Retrieving file: {self.path[10:]}")
+                    # print(f"Retrieving file: {self.path[9:]}")
                     self.path = urllib.parse.unquote(self.path[9:])
                     self.send_file_via_real_path()
                     return

--- a/src/swift/public/js/main.js
+++ b/src/swift/public/js/main.js
@@ -5,7 +5,7 @@ import { WebSocketTransport, portFromLocation } from "./comms.js";
 import { Recorder } from "./recording.js";
 import { FPS, SimTime } from "./hud.js";
 
-const { scene, camera, renderer, controls, axesHelper } = createScene();
+const { scene, camera, renderer, controls, axesHelper, groundMaterial } = createScene();
 
 const fps = new FPS(document.getElementById("fps"));
 const simTime = new SimTime(document.getElementById("sim-time"));
@@ -145,6 +145,10 @@ transport.onMessage((func, data) => {
     }
     case "browser_timeout": {
       autoCloseDelay = data;
+      break;
+    }
+    case "ground_opacity": {
+      groundMaterial.opacity = data;
       break;
     }
     case "camera_pose": {

--- a/src/swift/public/js/main.js
+++ b/src/swift/public/js/main.js
@@ -22,6 +22,11 @@ const uiElements = [];
 
 const UI_CLASSES = { slider: Slider, button: Button, label: Label, select: Select, checkbox: Checkbox, radio: Radio };
 
+// Seconds to wait after losing the connection before self-closing the tab
+// -- set by the "browser_timeout" message, sent right after launch()
+// connects (see Swift.py's launch(browser_timeout=)). null means never.
+let autoCloseDelay = null;
+
 function saveScreenshot(fileName) {
   const link = document.createElement("a");
   link.download = `${fileName}.png`;
@@ -55,7 +60,11 @@ transport.onClose(() => {
   // window.close() silently no-ops on a tab the browser didn't consider
   // script-opened, which is the common case here -- so don't rely on it
   // to clean up the now-stale sidenav controls, do that directly instead.
-  if (recorder.autoclose) setTimeout(() => window.close(), 5000);
+  // recorder.autoclose is only false mid-GIF-save (the user still needs
+  // the tab to trigger that download), independent of autoCloseDelay.
+  if (recorder.autoclose && autoCloseDelay !== null) {
+    setTimeout(() => window.close(), autoCloseDelay * 1000);
+  }
 
   const sidenav = document.getElementById("sidenav");
   sidenav.innerHTML = "";
@@ -132,6 +141,10 @@ transport.onMessage((func, data) => {
     }
     case "axes": {
       axesHelper.visible = data;
+      break;
+    }
+    case "browser_timeout": {
+      autoCloseDelay = data;
       break;
     }
     case "camera_pose": {

--- a/src/swift/public/js/scene.js
+++ b/src/swift/public/js/scene.js
@@ -61,12 +61,17 @@ export function createScene() {
   controls.target = new THREE.Vector3(0, 0, 0.2);
   controls.update();
 
-  const ground = new THREE.Mesh(
-    new THREE.PlaneGeometry(40, 40),
-    // DoubleSide -- materials are single-sided by default, which made
-    // the ground invisible when the camera orbited below it.
-    new THREE.MeshPhongMaterial({ color: 0x4b4b4b, specular: 0x101010, side: THREE.DoubleSide })
-  );
+  // DoubleSide -- materials are single-sided by default, which made the
+  // ground invisible when the camera orbited below it. transparent must
+  // be set for opacity (see the "ground_opacity" message) to have any
+  // effect at all -- three.js ignores opacity on an opaque material.
+  const groundMaterial = new THREE.MeshPhongMaterial({
+    color: 0x4b4b4b,
+    specular: 0x101010,
+    side: THREE.DoubleSide,
+    transparent: true,
+  });
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(40, 40), groundMaterial);
   ground.receiveShadow = true;
   scene.add(ground);
 
@@ -83,5 +88,5 @@ export function createScene() {
     renderer.setSize(window.innerWidth, window.innerHeight);
   });
 
-  return { scene, camera, renderer, controls, axesHelper };
+  return { scene, camera, renderer, controls, axesHelper, groundMaterial };
 }

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -348,3 +348,42 @@ def test_hold_keeps_waiting_while_still_connected(monkeypatch):
 
     env.hold()
     assert call_count[0] > 3
+
+
+def test_ground_opacity_only_sent_when_non_default():
+    # ground_opacity=1.0 matches the frontend's own default (an opaque
+    # material), so skipping the message when it's unchanged is safe --
+    # mirrors the axes= pattern. A non-default value must go out though.
+    env = make_env()
+    browser = FakeBrowser(env, responses=["0", "0"])
+    env.ground_opacity = 1.0
+
+    if env.ground_opacity != 1.0:
+        env._send_socket("ground_opacity", env.ground_opacity, expected=False)
+    env._add_controls()
+
+    codes = [c for c, _ in browser.received]
+    assert "ground_opacity" not in codes
+    browser.stop()
+
+
+def test_ground_opacity_sent_when_set():
+    import time
+
+    env = make_env()
+    browser = FakeBrowser(env, responses=["0", "0"])
+    env.ground_opacity = 0.3
+
+    env._add_controls()
+    if env.ground_opacity != 1.0:
+        env._send_socket("ground_opacity", env.ground_opacity, expected=False)
+
+    for _ in range(50):
+        if len(browser.received) >= 3:
+            break
+        time.sleep(0.01)
+
+    codes = [c for c, _ in browser.received]
+    assert codes == ["element", "element", "ground_opacity"]
+    assert browser.received[-1][1] == 0.3
+    browser.stop()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -272,3 +272,79 @@ def test_headless_realtime_still_paces_steps():
     elapsed = time.time() - t0
 
     assert elapsed >= 0.1, "headless step() did not pace to realtime_speed"
+
+
+def test_launch_sends_browser_timeout_after_connecting():
+    # Mirrors the tail of launch()'s connected-browser sequence: controls,
+    # then browser_timeout -- a value the frontend needs to know before a
+    # disconnect can happen, so it must go out at connect time, not lazily.
+    env = make_env()
+    browser = FakeBrowser(env, responses=["0", "0"])
+    env._browser_timeout = 5
+
+    import time
+
+    env._add_controls()
+    env._send_socket("browser_timeout", env._browser_timeout, expected=False)
+
+    # expected=False doesn't block for a reply, so give the FakeBrowser
+    # thread a moment to drain the queue before asserting on it.
+    for _ in range(50):
+        if len(browser.received) >= 3:
+            break
+        time.sleep(0.01)
+
+    codes = [c for c, _ in browser.received]
+    assert codes == ["element", "element", "browser_timeout"]
+    assert browser.received[-1][1] == 5
+    browser.stop()
+
+
+def test_hold_returns_once_disconnected_past_timeout(monkeypatch):
+    # Regression test: hold() used to loop forever regardless of whether
+    # the browser was still there, requiring a manual ^C even after the
+    # tab was long gone -- see Swift.py's hold()/launch()'s timeout=.
+    from types import SimpleNamespace
+
+    env = make_env()
+    env.headless = False
+    env.socket = SimpleNamespace(USERS=set())  # already disconnected
+    env._hold_timeout = 2
+
+    fake_now = [0.0]
+    monkeypatch.setattr(swift_module.time, "time", lambda: fake_now[0])
+    monkeypatch.setattr(swift_module.time, "sleep", lambda s: fake_now.__setitem__(0, fake_now[0] + 1.0))
+
+    env.hold()  # returns once disconnected for > 2s -- would hang otherwise
+    assert fake_now[0] > 2
+
+
+def test_hold_keeps_waiting_while_still_connected(monkeypatch):
+    from types import SimpleNamespace
+
+    env = make_env()
+    env.headless = False
+    env.socket = SimpleNamespace(USERS={"a-connected-browser"})
+    env._hold_timeout = 1
+
+    call_count = [0]
+
+    def fake_sleep(s):
+        call_count[0] += 1
+        if call_count[0] > 3:
+            # Still "connected" the whole time -- prove hold() really
+            # would have kept going by disconnecting only now, then let
+            # it return so the test itself terminates.
+            env.socket.USERS.clear()
+
+    fake_now = [0.0]
+    monkeypatch.setattr(swift_module.time, "time", lambda: fake_now[0])
+
+    def sleep_and_advance(s):
+        fake_sleep(s)
+        fake_now[0] += 1.0
+
+    monkeypatch.setattr(swift_module.time, "sleep", sleep_and_advance)
+
+    env.hold()
+    assert call_count[0] > 3

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -253,3 +253,22 @@ def test_speed_control_maps_select_index_to_speed_multiplier():
     env._time_control(0)
     assert env.realtime_speed is None
     browser.stop()
+
+
+def test_headless_realtime_still_paces_steps():
+    # Regression test for jhavl/swift#60: realtime_speed's pacing sleep
+    # used to sit entirely inside `if not self.headless`, so headless
+    # runs ignored it and ran flat-out regardless of realtime=True.
+    import time
+
+    env = make_env()
+    env.headless = True
+    env.realtime_speed = 1.0
+    env.last_time = time.time()
+
+    t0 = time.time()
+    for _ in range(3):
+        env.step(0.05)
+    elapsed = time.time() - t0
+
+    assert elapsed >= 0.1, "headless step() did not pace to realtime_speed"


### PR DESCRIPTION
Related to #48 (ground plane opacity from below, fixed separately in #64): makes the ground plane's opacity configurable instead of hardcoded fully-opaque.

Named \`ground_opacity\`, not \`ground_alpha\`, to match the wire protocol and three.js's own \`MeshPhongMaterial.opacity\` -- \`Shape.to_dict()\` already uses "opacity", and the existing \`robot_alpha\`/\`collision_alpha\` params' own docstrings describe them as "visual opacity" despite the alpha naming. That inconsistency predates this change and isn't fixed here (would break the existing public API); \`ground_opacity\` just doesn't compound it.

Stacked on #71 (feat/hold-timeout).