### PR TITLE
feat: add Slider precision= parameter, default 3

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -214,10 +214,14 @@ class Swift:
 
         ``env.show()`` prints every object currently added to the scene
         (shapes, assemblies/robots, and UI elements) with its id, type,
-        and name if one was given via ``name=`` at add time.
+        and name if one was given via ``name=`` at add time. The
+        pause/realtime-speed controls _add_controls() adds to every
+        launch() aren't user-added UI, so they're excluded here too.
         """
         print(repr(self))
         for eid, el in self.elements.items():
+            if el.builtin:
+                continue
             name = getattr(el, "name", None)
             print(f"  UI[{eid}] {type(el).__name__}" + (f' "{name}"' if name else ""))
 

--- a/src/swift/SwiftElement.py
+++ b/src/swift/SwiftElement.py
@@ -80,10 +80,19 @@ class Slider(SwiftElement):
     :type desc: str
     :param unit: add a unit to the slider value, optional
     :type unit: str
+    :param precision: number of *decimal places* shown for the current
+        value and the min/max range labels next to the slider -- e.g.
+        ``precision=3`` shows ``2.478``, not ``2.48`` (that would be 3
+        *significant figures* instead, a different, narrower value this
+        parameter does not control). Optional, defaults to 3. Purely a
+        display rounding -- the underlying value (what a callback or
+        ``env.values`` actually receives) always keeps full float
+        precision, e.g. whatever a step()-side computation produced.
+    :type precision: int
 
     """
 
-    def __init__(self, cb, min=0, max=100, step=1, value=0, desc='', unit=''):
+    def __init__(self, cb, min=0, max=100, step=1, value=0, desc='', unit='', precision=3):
         super(Slider, self).__init__()
 
         self._element = 'slider'
@@ -94,6 +103,7 @@ class Slider(SwiftElement):
         self.value = value
         self.desc = desc
         self.unit = unit
+        self.precision = precision
 
     @property
     def cb(self):
@@ -159,6 +169,15 @@ class Slider(SwiftElement):
     def unit(self, value):
         self._unit = value
 
+    @property
+    def precision(self):
+        return self._precision
+
+    @precision.setter
+    @SwiftElement._update
+    def precision(self, value):
+        self._precision = int(value)
+
     def to_dict(self):
         return {
             'element': self._element,
@@ -169,7 +188,8 @@ class Slider(SwiftElement):
             'step': self.step,
             'value': self.value,
             'desc': self.desc,
-            'unit': self.unit
+            'unit': self.unit,
+            'precision': self.precision,
         }
 
     def update(self, e):

--- a/src/swift/public/js/ui.js
+++ b/src/swift/public/js/ui.js
@@ -42,7 +42,14 @@ export class Slider {
     this.desc = document.getElementById(`desc${data.id}`);
 
     this.onInput = () => {
-      this.value.innerHTML = this.slider.value + this.unit;
+      // toFixed(), not toPrecision() -- this.precision is decimal places
+      // (2.478 at precision=3), not significant figures (2.48 at 3 sig
+      // figs -- a different, narrower value this does not implement).
+      // Rounds for display only -- the slider's own value (used for
+      // this.data/the actual reported value) keeps its raw float
+      // precision, e.g. any float step()-side arithmetic that produced
+      // it (0.30000000000000004 and the like).
+      this.value.innerHTML = Number(this.slider.value).toFixed(this.precision) + this.unit;
       this.changed = true;
       this.data = this.slider.value;
     };
@@ -54,12 +61,17 @@ export class Slider {
 
   update(data) {
     this.unit = data.unit;
+    this.precision = data.precision;
     this.slider.value = data.value;
     this.slider.step = data.step;
     this.slider.min = data.min;
     this.slider.max = data.max;
-    this.min.innerHTML = data.min;
-    this.max.innerHTML = data.max;
+    // The slider's own min/max (above) keep full precision -- only the
+    // text labels are rounded, same as the live value. Otherwise a range
+    // like min=-np.pi/max=np.pi shows -3.141592653589793 regardless of
+    // precision=, since these were never touched by that fix at all.
+    this.min.innerHTML = Number(data.min).toFixed(data.precision);
+    this.max.innerHTML = Number(data.max).toFixed(data.precision);
     this.desc.innerHTML = data.desc;
     this.onInput();
   }

--- a/tests/test_assembly_handle.py
+++ b/tests/test_assembly_handle.py
@@ -187,3 +187,29 @@ def test_show_does_not_raise(capsys):
     out = capsys.readouterr().out
     assert "my box" in out
     assert "panda" in out
+
+
+def test_show_excludes_builtin_controls(capsys):
+    # Regression test: show() used to list every element in self.elements
+    # unconditionally, so it always printed the pause/realtime-speed
+    # controls _add_controls() adds on every launch() -- even with zero
+    # user-added UI elements.
+    env = make_env()
+    env._add_controls()
+
+    env.show()
+    out = capsys.readouterr().out
+    assert "UI[" not in out
+
+
+def test_show_lists_user_elements_alongside_builtin_ones(capsys):
+    from swift import Slider
+
+    env = make_env()
+    env._add_controls()
+    env.add_ui(Slider(lambda v: None, desc="speed"), name="speed")
+
+    env.show()
+    out = capsys.readouterr().out
+    assert out.count("UI[") == 1
+    assert "speed" in out

--- a/tests/test_swift_element.py
+++ b/tests/test_swift_element.py
@@ -21,6 +21,7 @@ def test_slider_to_dict():
         "value": 2.5,
         "desc": "d",
         "unit": "u",
+        "precision": 3,
     }
 
 
@@ -28,6 +29,15 @@ def test_slider_update_from_browser():
     s = Slider(lambda v: None, value=0)
     s.update(7.5)
     assert s.value == 7.5
+
+
+def test_slider_precision_defaults_to_3_and_is_settable():
+    s = Slider(lambda v: None)
+    assert s.precision == 3
+
+    s2 = Slider(lambda v: None, precision=1)
+    assert s2.precision == 1
+    assert s2.to_dict()["precision"] == 1
 
 
 def test_button_to_dict():


### PR DESCRIPTION
The displayed value used the range input's raw value directly, so it showed however many decimal digits floating-point arithmetic happened to produce (e.g. a callback computing \`0.30000000000000004\`) -- now rounded for display via a new \`precision=\` (default 3). The underlying reported value (\`this.data\`, what actually reaches \`env.values\`) keeps its full float precision; only the on-screen text is rounded.

Stacked on #73 (fix/show-builtin-elements).