### PR TITLE
feat: browser/notebook connection lifecycle -- close() that actually closes, run(), Colab diagnostics

### DIFF
--- a/docs/notebooks/swift.ipynb
+++ b/docs/notebooks/swift.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "31f51cf5",
+   "metadata": {},
+   "source": [
+    "# Swift in a notebook cell\n",
+    "\n",
+    "Renders a Franka-Emika Panda (loaded from its URDF) inline in this cell's output, via `launch(browser=\"notebook\")`, instead of opening a separate browser tab -- then holds briefly and closes cleanly, clearing the cell's output.\n",
+    "\n",
+    "**Local use only.** Doesn't work on Google Colab -- see `tech-debt.md`'s \"Google Colab support\" section for details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af18ef6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Only installs if swift/roboticstoolbox aren't already importable --\n",
+    "# skipped entirely for a local dev checkout (editable install already on\n",
+    "# the path).\n",
+    "#\n",
+    "# TEMPORARY: pinned to our fork's in-progress branch, not jhavl/swift's\n",
+    "# `future` -- none of add_robot()/AssemblyHandle/this notebook's own\n",
+    "# fixes (run()/close(clear_cell=)/etc.) have merged upstream yet. Switch\n",
+    "# back to `git+https://github.com/jhavl/swift.git@future` (or drop this\n",
+    "# whole except: branch and just `pip install swift-sim`) once released.\n",
+    "try:\n",
+    "    import swift\n",
+    "    import roboticstoolbox as rtb\n",
+    "except ImportError:\n",
+    "    %pip install -q roboticstoolbox-python\n",
+    "    %pip install -q \"swift-sim @ git+https://github.com/petercorke/swift.git@feat/browser-lifecycle\"\n",
+    "    import swift\n",
+    "    import roboticstoolbox as rtb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f3e1554",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import roboticstoolbox as rtb\n",
+    "from swift import Swift\n",
+    "\n",
+    "env = Swift()\n",
+    "env.launch(browser=\"notebook\")\n",
+    "\n",
+    "panda = rtb.models.Panda()  # URDF-based model, not the analytic DH one\n",
+    "handle = env.add_robot(panda)\n",
+    "handle.q = panda.qr\n",
+    "env.step()  # add_robot() doesn't push an initial pose on its own -- step() does\n",
+    "# import time\n",
+    "# time.sleep(5)\n",
+    "env.hold(5)\n",
+    "env.close(clear_cell=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca5e516a",
+   "metadata": {},
+   "source": [
+    "If the cell above rendered the Panda in its ready pose inline, held for 5 seconds, then blanked the cell -- the notebook embedding path (`browser=\"notebook\"`), `hold(duration=)`, and `close(clear_cell=True)` all work as intended."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/box_orbit.py
+++ b/examples/box_orbit.py
@@ -14,7 +14,6 @@ A per-step callback computes and returns the pose directly -- swift
 owns t and calls it each env.step(), so there's no manual box.T
 assignment in the loop.
 """
-import time
 import spatialgeometry as sg
 import spatialmath as sm
 from swift import Swift
@@ -35,4 +34,3 @@ env.add_shape(box, callback=orbit)
 dt = 0.02
 while True:
     env.step(dt)
-    time.sleep(dt)

--- a/examples/box_sliders.py
+++ b/examples/box_sliders.py
@@ -9,7 +9,6 @@ Named sliders (name=...) push their value into env.values -- a
 per-step callback reads them from there, so there's no need to write a
 setter function per slider.
 """
-import time
 import spatialgeometry as sg
 from spatialmath import SE3
 from swift import Swift, Slider
@@ -34,4 +33,3 @@ env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, desc="
 
 while True:
     env.step(0.05)
-    time.sleep(0.05)

--- a/examples/panda_ik_sliders.py
+++ b/examples/panda_ik_sliders.py
@@ -11,7 +11,6 @@ read from there and return the new pose/q -- there's no explicit
 per-slider setter function, and no manual pose/q assignment in the
 loop, env.step() drives everything.
 """
-import time
 import numpy as np
 import roboticstoolbox as rtb
 import spatialgeometry as sg
@@ -60,4 +59,3 @@ env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, desc="
 
 while True:
     env.step(dt)
-    time.sleep(dt)

--- a/examples/two_link_arm.py
+++ b/examples/two_link_arm.py
@@ -12,7 +12,6 @@ model. That's the whole leap from this to a real robot: a kinematic
 model with more than two links, and swift building the handle instead
 of you calling add_assembly() by hand.
 """
-import time
 import numpy as np
 import spatialgeometry as sg
 from spatialmath import SE3
@@ -53,4 +52,3 @@ env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, d
 
 while True:
     env.step(0.05)
-    time.sleep(0.05)

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -181,6 +181,8 @@ class Swift:
         # applies even if this process was killed outright rather than
         # exiting through hold().
         self._browser_timeout = 5
+        # Set by launch(browser="notebook") -- see close()'s clear_cell=.
+        self._notebook_display_handle = None
 
     @property
     def rate(self):
@@ -315,7 +317,7 @@ class Swift:
         if not self.headless:
             # A flag for our threads to monitor for when to quit
             self._run_thread = True
-            self.socket, self.server = start_servers(
+            self.socket_thread, self.socket, self.server, self._notebook_display_handle = start_servers(
                 self.outq,
                 self.inq,
                 self._servers_running,
@@ -341,7 +343,13 @@ class Swift:
     def _stop_threads(self):
         self._run_thread = False
         if not self.headless:
-            self.socket.join(1)
+            # Setting _run_thread above only ends serve()'s per-connection
+            # message loop -- SwiftSocket.loop.run_forever() itself never
+            # checks it and would otherwise keep the thread (and the bound
+            # port) alive forever, regardless. stop() actually tells that
+            # event loop to return.
+            self.socket.stop()
+            self.socket_thread.join(1)
         if not self._dev:
             self.server.join(1)
 
@@ -370,85 +378,102 @@ class Swift:
 
         """
 
-        # Sim time is incremented first -- callbacks registered via
-        # add_shape()/add_assembly()/add_robot()'s callback= see the *new*
-        # t for this step, not the one before it.
-        self.sim_time += dt
-        t = self.sim_time
-        values = self.values
+        try:
+            # Sim time is incremented first -- callbacks registered via
+            # add_shape()/add_assembly()/add_robot()'s callback= see the
+            # *new* t for this step, not the one before it.
+            self.sim_time += dt
+            t = self.sim_time
+            values = self.values
 
-        # Update local pose of objects. A registered callback(t, values)
-        # -- returning an SE3 for a shape, or a q vector for an assembly/
-        # robot -- takes over entirely for that object; otherwise fall
-        # back to the existing velocity-integration/shape.v path.
-        for i, obj in enumerate(self.swift_objects):
-            if isinstance(obj, Shape):
-                cb = self.shape_callbacks.get(i)
-                if cb is not None:
-                    obj.T = cb(t, values)
-                else:
-                    self._step_shape(obj, dt)
-            elif isinstance(obj, AssemblyHandle):
-                if obj.callback is not None:
-                    obj.q = np.asarray(obj.callback(t, values), dtype=float)
-                else:
-                    self._step_assembly(obj, dt)
+            # Update local pose of objects. A registered callback(t, values)
+            # -- returning an SE3 for a shape, or a q vector for an
+            # assembly/robot -- takes over entirely for that object;
+            # otherwise fall back to the existing velocity-integration/
+            # shape.v path.
+            for i, obj in enumerate(self.swift_objects):
+                if isinstance(obj, Shape):
+                    cb = self.shape_callbacks.get(i)
+                    if cb is not None:
+                        obj.T = cb(t, values)
+                    else:
+                        self._step_shape(obj, dt)
+                elif isinstance(obj, AssemblyHandle):
+                    if obj.callback is not None:
+                        obj.q = np.asarray(obj.callback(t, values), dtype=float)
+                    else:
+                        self._step_assembly(obj, dt)
 
-        # Update world transform of shapes (assemblies/robots render via
-        # AssemblyHandle.part_poses(), a pure function of handle.q -- no
-        # scene-graph propagation needed, see tech-debt.md)
-        for obj in self.swift_objects:
-            if isinstance(obj, Shape):
-                obj._propogate_scene_tree()
+            # Update world transform of shapes (assemblies/robots render via
+            # AssemblyHandle.part_poses(), a pure function of handle.q --
+            # no scene-graph propagation needed, see tech-debt.md)
+            for obj in self.swift_objects:
+                if isinstance(obj, Shape):
+                    obj._propogate_scene_tree()
 
-        if self.realtime_speed:
-            # Delay progress if we're running too quickly for the target
-            # speed -- 0.5x should take twice as long (wall clock) per dt
-            # of simulated time as 1x, 0.25x four times as long, etc.
-            # Applies in headless mode too -- realtime pacing and
-            # rendering are independent concerns; only the rendering
-            # itself needs a live browser tab to skip.
-            time_taken = time.time() - self.last_time
-            diff = (dt * self._skipped) / self.realtime_speed - time_taken
-            self._skipped = 1
+            if self.realtime_speed:
+                # Delay progress if we're running too quickly for the
+                # target speed -- 0.5x should take twice as long (wall
+                # clock) per dt of simulated time as 1x, 0.25x four times
+                # as long, etc. Applies in headless mode too -- realtime
+                # pacing and rendering are independent concerns; only the
+                # rendering itself needs a live browser tab to skip. This
+                # sleep is also where most of a realtime-paced script's
+                # wall-clock time between step() calls actually goes --
+                # which is why ^C is caught around this whole method, not
+                # just here: it's overwhelmingly likely to land inside
+                # this call, not a caller's own sleep (if it even has one).
+                time_taken = time.time() - self.last_time
+                diff = (dt * self._skipped) / self.realtime_speed - time_taken
+                self._skipped = 1
 
-            if diff > 0:
-                time.sleep(diff)
+                if diff > 0:
+                    time.sleep(diff)
 
-            self.last_time = time.time()
+                self.last_time = time.time()
 
-        if not self.headless:
+            if not self.headless:
 
-            if render and self.rendering:
+                if render and self.rendering:
 
-                if not self.realtime_speed and (time.time() - self._laststep) < self._period:
-                    # Only render at 60 FPS
-                    self._skipped += 1
-                    return
+                    if not self.realtime_speed and (time.time() - self._laststep) < self._period:
+                        # Only render at 60 FPS
+                        self._skipped += 1
+                        return
 
-                self._laststep = time.time()
+                    self._laststep = time.time()
 
-                self._step_elements()
+                    self._step_elements()
 
-                events = self._draw_all()
+                    events = self._draw_all()
+                    # print(events)
+
+                    # Process GUI events
+                    self.process_events(events)
+
+                elif not self.rendering:
+                    if (time.time() - self._laststep) < self._notrenderperiod:
+                        return
+                    self._laststep = time.time()
+                    events = json.loads(self._send_socket("shape_poses", [], True))
+                    self.process_events(events)
+
                 # print(events)
+                # else:
+                #     for i in range(len(self.robots)):
+                #         self.robots[i]['ob'].fkine_all(self.robots[i]['ob'].q)
 
-                # Process GUI events
-                self.process_events(events)
-
-            elif not self.rendering:
-                if (time.time() - self._laststep) < self._notrenderperiod:
-                    return
-                self._laststep = time.time()
-                events = json.loads(self._send_socket("shape_poses", [], True))
-                self.process_events(events)
-
-            # print(events)
-            # else:
-            #     for i in range(len(self.robots)):
-            #         self.robots[i]['ob'].fkine_all(self.robots[i]['ob'].q)
-
-            self._send_socket("sim_time", self.sim_time, expected=False)
+                self._send_socket("sim_time", self.sim_time, expected=False)
+        except KeyboardInterrupt:
+            # ^C is the normal, expected way to end an interactive session
+            # here, not an error -- exit quietly rather than a traceback,
+            # regardless of what loop construct the caller wrote (a bare
+            # `while True: env.step(dt)` gets this for free, not just
+            # hold()/run(), which also catch it independently for the
+            # part of their own loops spent outside step()).
+            print("\nInterrupted, closing.")
+            self.close()
+            raise SystemExit
 
     def reset(self):
         """
@@ -490,16 +515,31 @@ class Swift:
         )
         self.realtime_speed = prior_speed
 
-    def close(self):
+    def close(self, clear_cell: bool = False):
         """
         Close the graphics display
 
         ``env.close()`` gracefully disconnectes from the Swift visualizer
         referenced by ``env``.
+
+        :param clear_cell: if launched with ``browser="notebook"``, blank
+            out the cell that rendered the iframe instead of leaving its
+            last frame visible (the default -- matches prior behaviour).
+            No effect for any other ``browser=`` mode, or if the iframe's
+            cell was never displayed (e.g. still headless).
+        :type clear_cell: bool
         """
 
         self._send_socket("close", "0", False)
         self._stop_threads()
+
+        if clear_cell and self._notebook_display_handle is not None:
+            # Lazy import -- IPython is optional, only actually needed if
+            # a notebook display handle was ever created in the first
+            # place (browser="notebook" already requires it be installed).
+            from IPython.display import HTML
+
+            self._notebook_display_handle.update(HTML(""))
 
     #
     #  Methods to interface with the robots created in other environemnts
@@ -773,51 +813,134 @@ class Swift:
         if not self.headless:
             self._send_socket(code, idd)
 
-    def hold(self, timeout: float | None = None):
+    def hold(self, duration: float | None = None, timeout: float | None = None):
         """
-        Block until the browser disconnects (or forever)
+        Block for up to ``duration`` seconds (or indefinitely)
 
         Meant to sit at the end of a script: once your simulation loop
         finishes, the script would otherwise exit immediately, killing
         this process and disconnecting the browser tab mid-view. ``hold()``
         keeps this process (and so the tab) alive so you can keep looking
-        at the final scene.
+        at the final scene -- for a fixed amount of time if ``duration``
+        is given, or until interrupted (^C) or the browser disconnects
+        for longer than ``timeout`` otherwise.
 
-        Returns once the browser has been disconnected (tab closed,
-        crashed, ...) for longer than ``timeout``, rather than holding
-        forever regardless of whether there's still a tab to hold open for
-        -- see :meth:`launch`'s ``timeout=``, which sets the default this
-        method uses when called with no argument.
+        ``duration`` is an unconditional cap -- it elapses regardless of
+        whether the browser is still connected, unlike ``timeout``, which
+        only ever starts counting *after* a disconnect. ``hold(5)`` reads
+        as "hold for 5 seconds" and does exactly that; it will still
+        return early if the browser goes away first.
 
+        :param duration: seconds to hold for, regardless of connection
+            state; ``None`` (default) holds indefinitely, bounded only
+            by ``timeout``/^C
+        :type duration: float | None
         :param timeout: seconds to keep waiting after the browser
-            disconnects before giving up and returning; defaults to
-            whatever :meth:`launch` was given (itself 5 by default).
-            ``None`` waits forever, matching the pre-2.1 behaviour.
+            disconnects before giving up and returning early; defaults
+            to whatever :meth:`launch` was given (itself 5 by default).
+            ``None`` never gives up on a disconnect (still stops at
+            ``duration``, if given).
         :type timeout: float | None
         """
 
         if timeout is None:
             timeout = self._hold_timeout
 
+        start_time = time.time()
         disconnected_since = None
 
         try:
-            while True:
+            while duration is None or (time.time() - start_time) < duration:
                 time.sleep(1)
-
-                if self.headless:
-                    continue
-
-                if len(self.socket.USERS) == 0:
-                    if disconnected_since is None:
-                        disconnected_since = time.time()
-                    elif timeout is not None and time.time() - disconnected_since > timeout:
-                        return
-                else:
-                    disconnected_since = None
+                disconnected_since, expired = self._check_disconnected(disconnected_since, timeout)
+                if expired:
+                    return
         except KeyboardInterrupt:
+            # ^C is the normal, expected way to end an interactive session
+            # here, not an error -- exit quietly rather than a traceback.
+            # SystemExit (not a plain return) so any code after this call
+            # doesn't keep running -- matches step()'s own handling of
+            # the same interrupt, since ^C landing inside a step() call
+            # this method makes (run()) is otherwise handled differently
+            # depending on exactly where it lands, which would be a
+            # confusing inconsistency.
+            print("\nInterrupted, closing.")
             self.close()
-            raise
+            raise SystemExit
+
+    def _check_disconnected(self, disconnected_since, timeout):
+        """
+        Shared disconnect-timeout bookkeeping for hold() and run().
+
+        :param disconnected_since: ``time.time()`` the browser was first
+            seen disconnected, or ``None`` if it wasn't (yet)
+        :type disconnected_since: float | None
+        :param timeout: seconds of continuous disconnection before
+            ``expired`` becomes True; ``None`` never expires
+        :type timeout: float | None
+        :return: updated ``disconnected_since``, and whether ``timeout``
+            has now been exceeded (headless never expires -- there's no
+            browser to disconnect from)
+        :rtype: tuple[float | None, bool]
+        """
+        if self.headless or len(self.socket.USERS) > 0:
+            return None, False
+        if disconnected_since is None:
+            return time.time(), False
+        expired = timeout is not None and time.time() - disconnected_since > timeout
+        return disconnected_since, expired
+
+    def run(self, duration: float | None = None, dt: float = 0.05, timeout: float | None = None):
+        """
+        Repeatedly call :meth:`step` until ``duration`` (sim-time seconds)
+        has elapsed, stopping early if the browser disconnects for longer
+        than ``timeout`` -- the same disconnect-timeout ``hold()`` uses,
+        and defaulting to the same :meth:`launch`'s ``timeout=`` value.
+
+        ``env.run()`` is the loop most scripts would otherwise hand-write
+        as ``while True: env.step(dt); time.sleep(dt)`` at the end of a
+        script, with hold()'s disconnect-awareness built in instead of
+        looping forever after the browser is long gone.
+
+        :param duration: sim-time seconds to run for; ``None`` runs until
+            disconnected (or forever, if ``timeout`` is also ``None``)
+        :type duration: float | None
+        :param dt: time step passed to each :meth:`step` call, defaults
+            to 0.05
+        :type dt: float
+        :param timeout: seconds to keep running after the browser
+            disconnects before giving up and returning; defaults to
+            whatever :meth:`launch` was given (itself 5 by default).
+            ``None`` never gives up on a disconnect (still stops at
+            ``duration``, if given).
+        :type timeout: float | None
+        """
+
+        if timeout is None:
+            timeout = self._hold_timeout
+
+        start_time = self.sim_time
+        disconnected_since = None
+
+        try:
+            while duration is None or (self.sim_time - start_time) < duration:
+                self.step(dt)
+                time.sleep(dt)
+                disconnected_since, expired = self._check_disconnected(disconnected_since, timeout)
+                if expired:
+                    return
+        except KeyboardInterrupt:
+            # ^C is the normal, expected way to end an interactive session
+            # here, not an error -- exit quietly rather than a traceback.
+            # SystemExit (not a plain return) so any code after this call
+            # doesn't keep running -- matches step()'s own handling of
+            # the same interrupt, since ^C landing inside a step() call
+            # this method makes (run()) is otherwise handled differently
+            # depending on exactly where it lands, which would be a
+            # confusing inconsistency.
+            print("\nInterrupted, closing.")
+            self.close()
+            raise SystemExit
 
     def start_recording(self, file_name, framerate, format="webm"):
         """

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -214,10 +214,14 @@ class Swift:
 
         ``env.show()`` prints every object currently added to the scene
         (shapes, assemblies/robots, and UI elements) with its id, type,
-        and name if one was given via ``name=`` at add time.
+        and name if one was given via ``name=`` at add time. The
+        pause/realtime-speed controls _add_controls() adds to every
+        launch() aren't user-added UI, so they're excluded here too.
         """
         print(repr(self))
         for eid, el in self.elements.items():
+            if el.builtin:
+                continue
             name = getattr(el, "name", None)
             print(f"  UI[{eid}] {type(el).__name__}" + (f' "{name}"' if name else ""))
 

--- a/src/swift/SwiftElement.py
+++ b/src/swift/SwiftElement.py
@@ -80,10 +80,19 @@ class Slider(SwiftElement):
     :type desc: str
     :param unit: add a unit to the slider value, optional
     :type unit: str
+    :param precision: number of *decimal places* shown for the current
+        value and the min/max range labels next to the slider -- e.g.
+        ``precision=3`` shows ``2.478``, not ``2.48`` (that would be 3
+        *significant figures* instead, a different, narrower value this
+        parameter does not control). Optional, defaults to 3. Purely a
+        display rounding -- the underlying value (what a callback or
+        ``env.values`` actually receives) always keeps full float
+        precision, e.g. whatever a step()-side computation produced.
+    :type precision: int
 
     """
 
-    def __init__(self, cb, min=0, max=100, step=1, value=0, desc='', unit=''):
+    def __init__(self, cb, min=0, max=100, step=1, value=0, desc='', unit='', precision=3):
         super(Slider, self).__init__()
 
         self._element = 'slider'
@@ -94,6 +103,7 @@ class Slider(SwiftElement):
         self.value = value
         self.desc = desc
         self.unit = unit
+        self.precision = precision
 
     @property
     def cb(self):
@@ -159,6 +169,15 @@ class Slider(SwiftElement):
     def unit(self, value):
         self._unit = value
 
+    @property
+    def precision(self):
+        return self._precision
+
+    @precision.setter
+    @SwiftElement._update
+    def precision(self, value):
+        self._precision = int(value)
+
     def to_dict(self):
         return {
             'element': self._element,
@@ -169,7 +188,8 @@ class Slider(SwiftElement):
             'step': self.step,
             'value': self.value,
             'desc': self.desc,
-            'unit': self.unit
+            'unit': self.unit,
+            'precision': self.precision,
         }
 
     def update(self, e):

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -46,6 +46,21 @@ def start_servers(
     open_tab: bool = True,
     browser: str | None = None,
 ):
+    # Warn up front, not just after a cold ~60s timeout with no context --
+    # see tech-debt.md's "Google Colab support" section. Not a hard block:
+    # still attempts the connection regardless, in case Colab's
+    # infrastructure has changed, or the user wants to see it fail
+    # themselves.
+    if COLAB:
+        print(
+            "\nHeads up: Colab is not currently a supported environment "
+            "for Swift. Every connection attempt made during testing has "
+            "failed (0/500 in isolated testing of Colab's own "
+            "proxyPort() proxy alone, with no Swift code involved at "
+            "all) -- see tech-debt.md's 'Google Colab support' section "
+            "for the full write-up. Attempting to connect anyway.\n"
+        )
+
     # Start our websocket server with a new port
     socket = Thread(
         target=SwiftSocket,
@@ -57,7 +72,7 @@ def start_servers(
         daemon=True,
     )
     socket.start()
-    socket_port = inq.get()
+    socket_port, socket_instance = inq.get()
 
     # Start a http server
     server = Thread(
@@ -74,6 +89,14 @@ def start_servers(
     server.start()
     server_port = inq.get()
 
+    # Only set for browser="notebook" -- a DisplayHandle (from
+    # display(..., display_id=True)) letting close() later blank out
+    # specifically the cell that rendered the iframe, regardless of
+    # which cell is executing when close() actually runs. A plain
+    # IPython.display.clear_output() only affects whatever cell is
+    # *currently* executing, which is normally a different, later one.
+    notebook_handle = None
+
     if open_tab:
         if COLAB:
             colab_url = eval_js(f"google.colab.kernel.proxyPort({server_port})")
@@ -89,12 +112,13 @@ def start_servers(
                         " install ipython'\n"
                     )
 
-                display(
+                notebook_handle = display(
                     IFrame(
                         src=url,
                         width="600",
                         height="400",
-                    )
+                    ),
+                    display_id=True,
                 )
             else:
                 try:
@@ -122,10 +146,20 @@ def start_servers(
     try:
         inq.get(timeout=handshake_timeout)
     except Empty:
-        print("\nCould not connect to the Swift simulator \n")
+        if COLAB:
+            print(
+                "\nCould not connect to the Swift simulator. As warned "
+                "above, Colab is not currently a supported environment "
+                "for Swift -- see tech-debt.md's 'Google Colab support' "
+                "section for the full evidence. We do not have a single "
+                "confirmed successful connection to point to (0/500 in "
+                "isolated testing), so retrying is unlikely to help.\n"
+            )
+        else:
+            print("\nCould not connect to the Swift simulator \n")
         raise
 
-    return socket, server
+    return socket, socket_instance, server, notebook_handle
 
 
 class SwiftSocket:
@@ -147,12 +181,21 @@ class SwiftSocket:
             except OSError:
                 port += 1
 
-        self.inq.put(port)
+        # self, not just the port, so the calling thread can actually stop
+        # this event loop later (see stop()) -- start_servers() previously
+        # only ever handed the caller the wrapping Thread, which has no
+        # way to reach into a *different* thread's running event loop.
+        self.inq.put((port, self))
         self.loop.run_forever()
 
     async def _start_server(self, port: int):
         # websockets>=11 requires serve() to be created from a running loop.
         self._server = await websockets.serve(self.serve, "localhost", port)
+
+    def stop(self):
+        # call_soon_threadsafe -- run_forever() is executing on a
+        # different thread than whichever one calls stop().
+        self.loop.call_soon_threadsafe(self.loop.stop)
 
     async def register(self, websocket):
         self.USERS.add(websocket)

--- a/src/swift/public/js/main.js
+++ b/src/swift/public/js/main.js
@@ -50,12 +50,21 @@ window.addEventListener("keydown", (e) => {
 
 const transport = new WebSocketTransport(`ws://localhost:${portFromLocation()}/`);
 
+// Guards animate()'s requestAnimationFrame chain -- otherwise it reschedules
+// itself forever regardless of connection state, rendering a static scene
+// and updating the FPS counter at full framerate indefinitely after
+// disconnect for no reason (found testing the notebook embedding path,
+// where the tab commonly can't self-close -- see browser_timeout's docs).
+let connected = false;
+
 transport.onOpen(() => {
   transport.send("Connected");
+  connected = true;
   requestAnimationFrame(animate);
 });
 
 transport.onClose(() => {
+  connected = false;
   if (recorder.active) recorder.stop();
   // window.close() silently no-ops on a tab the browser didn't consider
   // script-opened, which is the common case here -- so don't rely on it
@@ -185,6 +194,7 @@ transport.onMessage((func, data) => {
 });
 
 function animate() {
+  if (!connected) return; // freeze on the last frame instead of looping forever
   requestAnimationFrame(animate);
   renderer.render(scene, camera);
   recorder.captureFrame(renderer.domElement);

--- a/src/swift/public/js/ui.js
+++ b/src/swift/public/js/ui.js
@@ -42,7 +42,14 @@ export class Slider {
     this.desc = document.getElementById(`desc${data.id}`);
 
     this.onInput = () => {
-      this.value.innerHTML = this.slider.value + this.unit;
+      // toFixed(), not toPrecision() -- this.precision is decimal places
+      // (2.478 at precision=3), not significant figures (2.48 at 3 sig
+      // figs -- a different, narrower value this does not implement).
+      // Rounds for display only -- the slider's own value (used for
+      // this.data/the actual reported value) keeps its raw float
+      // precision, e.g. any float step()-side arithmetic that produced
+      // it (0.30000000000000004 and the like).
+      this.value.innerHTML = Number(this.slider.value).toFixed(this.precision) + this.unit;
       this.changed = true;
       this.data = this.slider.value;
     };
@@ -54,12 +61,17 @@ export class Slider {
 
   update(data) {
     this.unit = data.unit;
+    this.precision = data.precision;
     this.slider.value = data.value;
     this.slider.step = data.step;
     this.slider.min = data.min;
     this.slider.max = data.max;
-    this.min.innerHTML = data.min;
-    this.max.innerHTML = data.max;
+    // The slider's own min/max (above) keep full precision -- only the
+    // text labels are rounded, same as the live value. Otherwise a range
+    // like min=-np.pi/max=np.pi shows -3.141592653589793 regardless of
+    // precision=, since these were never touched by that fix at all.
+    this.min.innerHTML = Number(data.min).toFixed(data.precision);
+    this.max.innerHTML = Number(data.max).toFixed(data.precision);
     this.desc.innerHTML = data.desc;
     this.onInput();
   }

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -320,7 +320,7 @@ in this environment or wired into `swift`'s test suite.
 
 ---
 
-## Google Colab support: real bugs fixed, but `proxyPort()` itself appears unreliable
+## Google Colab support: not currently working, no fix planned for now
 
 ### Background
 
@@ -360,36 +360,150 @@ all):
    server can't handle without stalling the real request.
 
 After all three fixes, the initial request through
-`google.colab.kernel.proxyPort()` still fails **intermittently** --
-same code, same steps, sometimes a 404 (on `favicon.ico`, harmless)
-with the actual page still blank, sometimes the request never
-completes at all (no status, no response headers, indistinguishable
-from a hang). Ruled out browser caching as the cause (tested in a
-private/incognito window, same intermittent failure). The
-inconsistency itself -- identical steps producing different outcomes
--- points at Colab's proxy infrastructure rather than a deterministic
-bug in this code, consistent with a documented history of `proxyPort`
-reliability issues (e.g. googlecolab/colabtools#4270, #3308, #4738 --
-the last of these was from 2024, already closed, not the current
-issue, but establishes the pattern).
+`google.colab.kernel.proxyPort()` still failed. Original
+back-and-forth testing showed two different failure *symptoms* across
+identical steps (sometimes a 404 on `favicon.ico` with the actual page
+still blank, sometimes the request never completing at all -- no
+status, no response headers, indistinguishable from a hang); ruled out
+browser caching as the cause (tested in a private/incognito window,
+same result either way).
 
-### Implication for the WebRTC decision
+**Update 2026-08-02 -- quantified, not just "sometimes fails."** Ran a
+minimal, Swift-independent isolation test (no roboticstoolbox, no
+websocket, just a bare `http.server` returning "OK" behind
+`proxyPort()`, hit with 500 consecutive requests, 3s timeout each,
+0.5s between attempts): **0 successes in 500 attempts** (mostly 404,
+a handful of read-timeouts). Do not have a single confirmed successful
+`proxyPort()` connection to point to, from any test run, on any
+`browser=` mode, ever. "Unreliable"/"intermittent" as used in the
+original write-up above overclaimed -- that implies occasional
+success, which we have no evidence for. What we actually have evidence
+for is: fails every time tried, with inconsistent failure symptoms
+(pointing at Colab's proxy infrastructure rather than a deterministic
+bug in this code -- see googlecolab/colabtools#4270, #3308, #4738 for
+the documented pattern, though none of those are the current issue).
 
-Confirmed this isn't a reason to reconsider dropping WebRTC: RTC would
-only have replaced the *data channel* after the page loads. The
-observed failure is in the *initial page load* through `proxyPort()`
-itself, before any comms-mode-specific code runs -- RTC wouldn't have
-helped with what's actually breaking.
+### A second, separate, structural bug found the same day -- NOT the root cause of the above, but real and worth fixing eventually
+
+`public/js/main.js` hardcodes the live data connection as
+`ws://localhost:${port}/` (see `comms.js`'s `WebSocketTransport`).
+Only the *initial HTML page load* gets routed through
+`google.colab.kernel.proxyPort()` (see `colab_url` above); the
+WebSocket URL never does -- it's passed through as a query-string
+port number and reconnected to literally as `localhost` on whatever
+machine is running the browser. On Colab that's the user's own local
+machine, not the remote VM Swift's process actually runs on, so even
+a *perfectly reliable* `proxyPort()` wouldn't be enough on its own --
+the initial page could load fine and the WebSocket would still try to
+reach a port with nothing listening on it.
+
+The likely fix, if this is ever revisited: also proxy the socket port
+(`eval_js(f"google.colab.kernel.proxyPort({socket_port})")`) and use
+the returned URL (rewritten `wss://`) instead of a hardcoded
+`ws://localhost`, the same way the HTTP server URL already works --
+*assuming* Colab's proxy supports the WebSocket upgrade handshake,
+which is untested. **Not implemented. No fix planned right now** (see
+Decision below) -- documented so a future attempt doesn't have to
+rediscover it, and so "found the bug" isn't mistaken for "fixed the
+bug."
+
+### Ruled out: reviving WebRTC
+
+An AI assistant (Gemini, consulted 2026-08-02) suggested this class of
+restriction is why WebRTC support originally existed in this codebase,
+and that reviving it might be worth prioritizing. Checked, not taken
+on faith: (a) its cited source is about `BroadcastChannel`, a
+same-page iframe-to-iframe messaging API -- unrelated to
+WebSocket-to-backend connectivity, doesn't actually support the claim;
+(b) per `0d122d1`'s own commit message (already on `future`, predates
+this investigation), the removed WebRTC code was "an unmodified copy
+of aiortc's own bundled example server (webcam capture +
+cartoon/edge/rotate video transform)... genuinely webcam/mic capture
+from the browser, not three.js scene streaming" -- dead demo
+boilerplate, never adapted for Swift's actual pose-streaming use case,
+no evidence it was ever meant to route around a Colab-specific
+restriction. Not reconsidering WebRTC on this basis.
+
+### A more promising direction, if Colab is ever revisited: `eval_js`/`register_callback` instead of a raw WebSocket
+
+Read the actual notebook behind the Gemini citation above directly
+(not just the text snippet Gemini quoted) to check what
+`google.colab.output` genuinely offers, since the specific claim
+didn't hold up but the general area seemed worth checking properly:
+
+- `google.colab.output.eval_js(js)` -- blocking call from Python,
+  evaluates JS "within the context of the outputframe of the current
+  cell" and returns the result (resolves Promises too). Already
+  proven partially reliable in this codebase's own existing Colab
+  path -- it's exactly what fetches `colab_url` via `proxyPort()`
+  today.
+- `google.colab.output.register_callback(name, fn)` /
+  `google.colab.kernel.invokeFunction()` (JS side) -- lets JS in a
+  cell's outputframe call back into Python, for "trusted" outputs
+  (executed within the current session).
+- Both are Colab's own first-class, documented bridge specifically
+  across the kernel <-> outputframe boundary -- confirmed sandboxed
+  ("the output of each cell is hosted in a separate iframe sandbox")
+  -- rather than a generic port-forwarding proxy never hardened for
+  this kind of interactive back-and-forth.
+
+This is architecturally more promising than trying to route the raw
+WebSocket through `proxyPort()` (the fix noted above): `eval_js`/
+`register_callback` are Colab's actual supported mechanism for this
+exact problem, not a workaround of a mechanism built for something
+else. It would mean a genuine third transport implementation --
+`comms.js`'s `WebSocketTransport` already has a docstring anticipating
+exactly this kind of second transport (originally imagined as
+postMessage/pyodide), so this wouldn't be fighting the existing
+architecture -- paired with a parallel Python-side route module using
+`eval_js`/`register_callback` instead of `websockets`/`http.server`.
+
+Open question before committing to this: `eval_js` is a blocking
+round-trip through the kernel comm channel, and Swift's `step()` loop
+wants up to 60Hz pose updates -- unknown whether that holds up at
+that frequency without prototyping it; Colab-specific throttling of
+the update rate might be necessary regardless of transport.
+
+**Not being pursued now** -- a genuine refactor, and Colab isn't a
+currently-supported target (see Decision below) -- but worth
+recording as the credible direction rather than starting from zero if
+this ever gets revisited.
+
+### Decision: no Colab support for now
+
+Not investing further here without new evidence. `launch()` now
+detects Colab at the start of `start_servers()` and prints a clear
+warning up front (before attempting anything, not just after a 60s
+timeout) rather than letting a user hit a cold "could not connect"
+after a long wait with no context. It still attempts the connection
+regardless -- not a hard block -- in case Colab's infrastructure
+changes, or a user wants to see the failure for themselves.
 
 ### Status
 
-Not resolved. The three fixes above are real, confirmed improvements
-worth keeping regardless (any Colab user gets further than before),
-but further progress needs either reproducing this outside of live
-back-and-forth debugging (a throwaway minimal `proxyPort()` Colab
-notebook with no Swift involved, to isolate whether *any* custom local
-server behaves reliably through it) or accepting Colab support as
-presently unreliable for reasons outside this repo's control.
+Not resolved, not currently being worked on. The three original fixes
+are real, confirmed improvements worth keeping regardless (any Colab
+user who does get through gets further than before), but Colab is not
+a supported environment right now -- both known issues (`proxyPort()`
+reliability, outside this repo's control; the un-proxied WebSocket,
+inside this repo's control but unfixed) would need addressing, and
+neither is planned.
+
+### `browser="notebook"` (inline iframe) tested on Colab too -- same failure
+
+Tested 2026-08-02 via `docs/notebooks/swift.ipynb`, using
+`launch(browser="notebook")` (renders inline via `IPython.display.IFrame`)
+instead of the tab-opening path. Structurally this sidesteps one whole
+class of problem the tab path has to work around -- an `<iframe>` is a
+normal DOM element, not a `window.open()` call, so it was never at risk
+of Colab's popup blocking. Didn't help: same "Could not connect to the
+Swift simulator" handshake timeout as the tab path, i.e. the initial
+page load through `proxyPort()` itself didn't complete. Consistent
+with the conclusion above -- the failure is in `proxyPort()` (and
+separately, the un-proxied WebSocket), not in anything about *how* the
+resulting URL gets opened, so tab vs iframe doesn't change the
+outcome. Confirmed locally (both plain browser tab and the notebook
+iframe) that the underlying code is otherwise correct.
 
 ---
 

--- a/tests/test_assembly_handle.py
+++ b/tests/test_assembly_handle.py
@@ -187,3 +187,29 @@ def test_show_does_not_raise(capsys):
     out = capsys.readouterr().out
     assert "my box" in out
     assert "panda" in out
+
+
+def test_show_excludes_builtin_controls(capsys):
+    # Regression test: show() used to list every element in self.elements
+    # unconditionally, so it always printed the pause/realtime-speed
+    # controls _add_controls() adds on every launch() -- even with zero
+    # user-added UI elements.
+    env = make_env()
+    env._add_controls()
+
+    env.show()
+    out = capsys.readouterr().out
+    assert "UI[" not in out
+
+
+def test_show_lists_user_elements_alongside_builtin_ones(capsys):
+    from swift import Slider
+
+    env = make_env()
+    env._add_controls()
+    env.add_ui(Slider(lambda v: None, desc="speed"), name="speed")
+
+    env.show()
+    out = capsys.readouterr().out
+    assert out.count("UI[") == 1
+    assert "speed" in out

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,6 +13,7 @@ frontend has no way to detect on its own.
 import importlib
 import json
 import threading
+from queue import Queue
 
 import pytest
 import roboticstoolbox as rtb
@@ -387,3 +388,137 @@ def test_ground_opacity_sent_when_set():
     assert codes == ["element", "element", "ground_opacity"]
     assert browser.received[-1][1] == 0.3
     browser.stop()
+
+
+def test_start_servers_socket_thread_actually_stops_on_close():
+    # Regression test for a real bug FakeBrowser-based tests structurally
+    # can't catch: everything above drains Swift's outq/inq directly, never
+    # touching start_servers()/SwiftSocket at all. That let two real bugs
+    # ship together -- self.socket used to be the wrapping Thread (no
+    # .USERS, breaking hold()'s disconnect polling), and _stop_threads()
+    # set a flag SwiftSocket.loop.run_forever() never checked, so close()
+    # never actually stopped the background thread or freed the port. This
+    # exercises the real SwiftSocket over a real socket instead.
+    from swift.SwiftRoute import SwiftSocket
+
+    outq, inq = Queue(), Queue()
+    run_flag = [True]
+    t = threading.Thread(
+        target=SwiftSocket, args=(outq, inq, lambda: run_flag[0]), daemon=True
+    )
+    t.start()
+    port, instance = inq.get(timeout=5)
+
+    assert isinstance(instance.USERS, set)  # what hold() polls
+
+    # Mirrors what Swift.close() -> _stop_threads() actually does: queue a
+    # message (unblocks producer()'s blocking outq.get()), then stop().
+    run_flag[0] = False
+    outq.put([False, ["close", "0"]])
+    instance.stop()
+
+    t.join(timeout=3)
+    assert not t.is_alive(), "SwiftSocket's thread did not actually stop"
+
+
+def test_hold_duration_returns_even_while_still_connected(monkeypatch):
+    # Regression test: hold(5) used to map its positional arg to timeout=
+    # (a grace period that only starts counting AFTER a disconnect), so a
+    # still-connected browser meant it never returned -- not what hold(5)
+    # reads as. duration= is an unconditional cap, connected or not.
+    from types import SimpleNamespace
+
+    env = make_env()
+    env.headless = False
+    env.socket = SimpleNamespace(USERS={"still-connected"})
+
+    fake_now = [0.0]
+    monkeypatch.setattr(swift_module.time, "time", lambda: fake_now[0])
+    monkeypatch.setattr(swift_module.time, "sleep", lambda s: fake_now.__setitem__(0, fake_now[0] + 1.0))
+
+    env.hold(duration=5)  # must return on its own -- would hang otherwise
+    assert fake_now[0] >= 5
+
+
+def test_run_calls_step_and_stops_at_duration():
+    env = make_env()
+    env.headless = True
+
+    steps = []
+    orig_step = env.step
+
+    def counting_step(dt=0.05, render=True):
+        steps.append(dt)
+        orig_step(dt, render=False)
+
+    env.step = counting_step
+    env.run(duration=0.2, dt=0.05)
+
+    assert len(steps) >= 4  # 0.2 / 0.05, allowing for real-time slop
+    assert env.sim_time >= 0.2
+
+
+def test_run_exits_quietly_on_keyboard_interrupt(monkeypatch):
+    # ^C is the normal way to end an interactive session here, not an
+    # error -- run()/hold()/step() must not let it propagate as a
+    # traceback. They raise SystemExit instead of returning normally, so
+    # any code after the call doesn't keep running either -- pytest.raises
+    # confirms that without actually killing the test process (SystemExit
+    # uncaught at the real top level is what exits quietly, not something
+    # visible inside a caught exception).
+    env = make_env()
+    env.headless = True
+
+    def sleep_raises(s):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(swift_module.time, "sleep", sleep_raises)
+    closed = []
+    env.close = lambda *a, **kw: closed.append(True)
+
+    with pytest.raises(SystemExit):
+        env.run()
+
+    assert closed == [True]
+
+
+def test_hold_exits_quietly_on_keyboard_interrupt(monkeypatch):
+    env = make_env()
+    env.headless = True
+
+    def sleep_raises(s):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(swift_module.time, "sleep", sleep_raises)
+    closed = []
+    env.close = lambda *a, **kw: closed.append(True)
+
+    with pytest.raises(SystemExit):
+        env.hold()
+
+    assert closed == [True]
+
+
+def test_step_exits_quietly_on_keyboard_interrupt(monkeypatch):
+    # step() itself catches ^C too, not just hold()/run() -- most of a
+    # realtime-paced script's wall-clock wait happens inside step()'s own
+    # pacing sleep, so ^C is overwhelmingly likely to land there even for
+    # a bare `while True: env.step(dt)` loop with no handling of its own.
+    import time as time_module
+
+    env = make_env()
+    env.headless = True
+    env.realtime_speed = 1.0
+    env.last_time = time_module.time()  # small/near-zero time_taken -> diff > 0 -> sleeps
+
+    def sleep_raises(s):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(swift_module.time, "sleep", sleep_raises)
+    closed = []
+    env.close = lambda *a, **kw: closed.append(True)
+
+    with pytest.raises(SystemExit):
+        env.step(0.05)
+
+    assert closed == [True]

--- a/tests/test_swift_element.py
+++ b/tests/test_swift_element.py
@@ -21,6 +21,7 @@ def test_slider_to_dict():
         "value": 2.5,
         "desc": "d",
         "unit": "u",
+        "precision": 3,
     }
 
 
@@ -28,6 +29,15 @@ def test_slider_update_from_browser():
     s = Slider(lambda v: None, value=0)
     s.update(7.5)
     assert s.value == 7.5
+
+
+def test_slider_precision_defaults_to_3_and_is_settable():
+    s = Slider(lambda v: None)
+    assert s.precision == 3
+
+    s2 = Slider(lambda v: None, precision=1)
+    assert s2.precision == 1
+    assert s2.to_dict()["precision"] == 1
 
 
 def test_button_to_dict():


### PR DESCRIPTION
Two bugs found testing the notebook embedding path for real (not mocked), plus the features that came out of fixing them properly.

**`close()` didn't actually close anything.** `_stop_threads()` set a flag `SwiftSocket.loop.run_forever()` never checked, so the background thread (and the bound port) never actually stopped. Related: `self.socket` was the wrapping `Thread`, not the `SwiftSocket` instance, so `hold()`'s `self.socket.USERS` check (shipped in #71) would have raised `AttributeError` the first time anyone called it. Both fixed by threading the real `SwiftSocket` instance back through `start_servers()`, plus a new `SwiftSocket.stop()` that actually stops its event loop.

**`hold(5)` never returned on a still-connected browser.** Its first positional arg meant "grace period after a disconnect" (`timeout=`), so `hold(5)` on a connected tab just waited forever -- not what `hold(5)` reads as. `duration=` is now the primary arg: an unconditional cap regardless of connection state; `timeout=` keeps its original meaning as a keyword arg.

**New `run(duration=, dt=, timeout=)`** loops `step()` with the same disconnect-awareness `hold()` has, instead of the hand-written `while True: env.step(dt); time.sleep(dt)` every script otherwise needs.

**New `close(clear_cell=)`** blanks a `browser="notebook"` cell's iframe via a `DisplayHandle`, since a plain `clear_output()` would only ever clear whichever cell happens to be executing `close()`, not the original cell that displayed it.

**`main.js`'s `animate()`** rescheduled itself forever regardless of connection state -- found testing the notebook path, where the tab commonly can't self-close. Now stops on disconnect instead of rendering a frozen scene at full framerate indefinitely.

**Colab**: `start_servers()` now warns up front when Colab is detected, before attempting anything, instead of only after a cold ~60s timeout. `tech-debt.md`'s Colab section has much harder evidence now (a minimal, Swift-independent 500-attempt isolation test: 0 successes) replacing the earlier "intermittently unreliable" framing, plus a second, separate, un-proxied-WebSocket bug found the same day, and why reviving WebRTC doesn't apply here.

Adds `docs/notebooks/swift.ipynb` demonstrating `browser="notebook"` + `hold(duration=)`/`close(clear_cell=)` end-to-end -- confirmed working locally.

Also adds one real (non-mocked) integration test against `SwiftSocket` over an actual socket, closing the gap that let the `self.socket` type bug ship in the first place -- every existing test drained Swift's `outq`/`inq` directly via a scripted fake browser, never touching `start_servers()`.

Stacked on #74 (feat/slider-precision).