### PR TITLE
ci: run the Python test suite and JS unit tests on push/PR

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,61 @@
+# Runs Swift's Python test suite (tests/) and the JS unit tests
+# (src/swift/public/js/*.test.js) on every push/PR -- previously nothing
+# in CI ever ran either; only src/swift/public/**'s vendored-asset check
+# existed (see vendor-check.yml). See tech-debt.md for the mocked-vs-real
+# testing gap this is partly closing.
+
+name: Python tests
+
+on:
+  push:
+    branches: [main, future]
+  pull_request:
+    branches: [main, future]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build-time dependencies
+        # roboticstoolbox-python's own setup.py fails inside pip's default
+        # isolated build environment (ModuleNotFoundError: No module named
+        # 'pip' -- a known class of issue with legacy setup.py's that
+        # import pip internally, which an isolated build env doesn't
+        # guarantee). --no-build-isolation below runs builds against the
+        # ambient environment instead, which needs numpy (swift-sim's own
+        # C extension, phys.cpp, imports it at build time) and
+        # setuptools/wheel present upfront since nothing will install them
+        # into an isolated env for us anymore.
+        run: pip install numpy setuptools wheel
+
+      - name: Install roboticstoolbox-python and dev/test tools
+        # roboticstoolbox-python's published versions pin swift-sim~=1.0.0
+        # -- directly incompatible with editable-installing *this* repo's
+        # swift-sim==2.0.0 (unreleased) in the same resolution pass. This
+        # installs it (and its own deps -- spatialgeometry, numpy, scipy,
+        # etc.) first, satisfying that pin normally with a real PyPI
+        # swift-sim 1.x; the next step then replaces it with this repo's
+        # editable version via --no-deps, without pip re-litigating the
+        # now-"broken" pin (see tech-debt.md: swift/roboticstoolbox/
+        # spatialgeometry are developed together across git branches,
+        # ahead of what's actually released).
+        run: pip install roboticstoolbox-python~=1.0.0 websockets pytest pytest-cov black flake8 pyyaml
+
+      - name: Install swift-sim itself (editable, no dependency re-resolution)
+        run: pip install --no-build-isolation --no-deps -e .
+
+      - name: Run Python tests
+        run: pytest tests/ -v
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run JS unit tests
+        run: node --test src/swift/public/js/*.test.js

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,17 +35,15 @@ jobs:
         run: pip install numpy setuptools wheel
 
       - name: Install roboticstoolbox-python and dev/test tools
-        # roboticstoolbox-python's published versions pin swift-sim~=1.0.0
-        # -- directly incompatible with editable-installing *this* repo's
-        # swift-sim==2.0.0 (unreleased) in the same resolution pass. This
-        # installs it (and its own deps -- spatialgeometry, numpy, scipy,
-        # etc.) first, satisfying that pin normally with a real PyPI
-        # swift-sim 1.x; the next step then replaces it with this repo's
-        # editable version via --no-deps, without pip re-litigating the
-        # now-"broken" pin (see tech-debt.md: swift/roboticstoolbox/
-        # spatialgeometry are developed together across git branches,
-        # ahead of what's actually released).
-        run: pip install roboticstoolbox-python~=1.0.0 websockets pytest pytest-cov black flake8 pyyaml
+        # tests/ exercises Robot.fkine_geometry(q), added to
+        # roboticstoolbox-python on the feat/fkine-geometry branch but not
+        # yet released to PyPI (swift/roboticstoolbox/spatialgeometry are
+        # developed together across git branches, ahead of what's actually
+        # released -- see tech-debt.md). Installing from that branch
+        # directly, same idea as installing swift-sim itself from source
+        # below. spatialgeometry is listed explicitly so it isn't left to
+        # whatever roboticstoolbox-python's own pin happens to resolve to.
+        run: pip install "git+https://github.com/petercorke/robotics-toolbox-python.git@feat/fkine-geometry" spatialgeometry websockets pytest pytest-cov black flake8 pyyaml
 
       - name: Install swift-sim itself (editable, no dependency re-resolution)
         run: pip install --no-build-isolation --no-deps -e .

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -543,6 +543,35 @@ isn't forgotten once the current frontend-rebuild work is committed.
 
 ---
 
+## `ci/python-tests` depends on an unreleased `roboticstoolbox-python` branch
+
+`.github/workflows/python-tests.yml` originally pinned
+`roboticstoolbox-python~=1.0.0` (a leftover from before swift-sim's 2.0
+rewrite). That pin restricts pip to RTB 1.0.x, which in turn pins
+`spatialgeometry~=1.0.0` -- an old, pre-nanobind-migration release that
+*is* genuinely compiled against the legacy NumPy 1.x C-API and hard-crashes
+under NumPy 2.x at import time. This looked, initially, like a NumPy-2
+compatibility bug in spatialgeometry's *current* published wheel -- it
+isn't; spatialgeometry 1.2.0 (current latest) is nanobind-based
+(`nb::ndarray<>`) and has no NumPy ABI dependency at all (confirmed via
+`otool -L` against the actual wheel: no NumPy symbols). The old pin was
+just quietly forcing an old, unrelated spatialgeometry version to be
+installed alongside it.
+
+Fixing the stale pin surfaced a second, real issue: `tests/` exercises
+`Robot.fkine_geometry(q)`, which doesn't exist on *any* released RTB --
+it only exists on `feat/fkine-geometry`
+(`petercorke/robotics-toolbox-python`, commit `8dbb44e2`, pushed
+2026-08-02). `ci/python-tests` now installs RTB directly from that branch
+via `pip install git+https://...@feat/fkine-geometry`, the same idea as
+installing swift-sim itself from source (see the next workflow step).
+
+**Follow-up**: once `feat/fkine-geometry` merges to RTB's `main` and a new
+RTB version is released to PyPI, switch `python-tests.yml` back to a normal
+version pin instead of the git branch reference.
+
+---
+
 ## `_fknm_c` background-thread nanobind leak affects every Swift session
 
 Fully written up in `roboticstoolbox-python/tech-debt.md` under


### PR DESCRIPTION
Nothing in CI ever ran `tests/` (62 tests) or `src/swift/public/js/*.test.js` before this -- `vendor-check.yml` only checks vendored three.js assets match their pinned versions, and `cibuildwheel.yml` only runs on a release. Every test result referenced across this session's PRs was only ever verified locally, never independently by CI.

**Untested against a real CI run yet** -- expect this may need iteration (system packages for compiled dependencies, exact Python version, etc. can only really be confirmed by actually running it). Will follow up on this PR as runs come in.

Stacked on #75 (feat/browser-lifecycle).