### PR TITLE
fix: SwiftServer's HTTP thread never stopped, leaking every shape ever added

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -317,7 +317,7 @@ class Swift:
         if not self.headless:
             # A flag for our threads to monitor for when to quit
             self._run_thread = True
-            self.socket_thread, self.socket, self.server, self._notebook_display_handle = start_servers(
+            self.socket_thread, self.socket, self.server_thread, self.server, self._notebook_display_handle = start_servers(
                 self.outq,
                 self.inq,
                 self._servers_running,
@@ -351,7 +351,16 @@ class Swift:
             self.socket.stop()
             self.socket_thread.join(1)
         if not self._dev:
-            self.server.join(1)
+            # server.stop() (httpd.shutdown()) is what actually lets
+            # serve_forever() return -- without it, Thread.run() never
+            # reaches its own cleanup of the arguments it was started
+            # with, one of which is a bound method of this Swift
+            # instance. That single un-cleared reference, from a thread
+            # that runs for the rest of the process's life, is what was
+            # keeping every shape ever added (and this env itself) alive
+            # long after close() returned -- see tech-debt.md.
+            self.server.stop()
+            self.server_thread.join(1)
 
     def step(self, dt=0.05, render=True):
         """

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -87,7 +87,7 @@ def start_servers(
     )
 
     server.start()
-    server_port = inq.get()
+    server_port, server_instance = inq.get()
 
     # Only set for browser="notebook" -- a DisplayHandle (from
     # display(..., display_id=True)) letting close() later blank out
@@ -159,7 +159,7 @@ def start_servers(
             print("\nCould not connect to the Swift simulator \n")
         raise
 
-    return socket, socket_instance, server, notebook_handle
+    return socket, socket_instance, server, server_instance, notebook_handle
 
 
 class SwiftSocket:
@@ -323,9 +323,25 @@ class SwiftServer:
                 # visible error on either side.
                 with socketserver.ThreadingTCPServer(("", server_port), Handler) as httpd:
                     httpd.daemon_threads = True
-                    self.inq.put(server_port)
+                    self.httpd = httpd
+                    self.inq.put((server_port, self))
                     connected = True
 
                     httpd.serve_forever()
             except OSError:
                 server_port += 1
+
+    def stop(self):
+        # serve_forever() never returns on its own (nothing ever called
+        # shutdown() before this) -- Thread.run() (which called
+        # SwiftServer(...), which is blocked inside serve_forever()) never
+        # reaches its own internal cleanup of self._target/_args/_kwargs
+        # as a result, so the wrapping Thread object keeps alive whatever
+        # was passed as this class's `run` callback for the whole process
+        # lifetime -- in practice, a bound method of the Swift instance
+        # itself, keeping the entire env (and every shape ever added)
+        # alive long after close() returns. shutdown() must be called
+        # from a different thread than the one running serve_forever()
+        # (Python's own requirement), which is always true here -- this
+        # is called from the thread that called close().
+        self.httpd.shutdown()

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -572,20 +572,62 @@ version pin instead of the git branch reference.
 
 ---
 
-## `_fknm_c` background-thread nanobind leak affects every Swift session
+## `spatialgeometry.scene._Node` nanobind leak on every Swift session -- fixed 2026-08-02
 
-Fully written up in `roboticstoolbox-python/tech-debt.md` under
-"`_fknm_c` (nanobind) leaks `_ETObj`/`_ETSObj` when created from a
-background thread" — root-caused there to fknm object creation
-specifically from a non-main thread, not call volume. Directly
-relevant here since Swift's stepping/rendering machinery always runs
-on a background thread, so any script using the Swift backend is a
-candidate to print the `nanobind: leaked N instances!` messages at
-interpreter shutdown (seen throughout this session's E2E test output).
-Confirmed cosmetic (a shutdown-time diagnostic) in every session this
-work generated, but not confirmed to rule out real memory growth in a
-long-running process — see the RTB entry for the open question and
-repro.
+Superseded two earlier, incorrect hypotheses (both investigated and ruled
+out this session): "`_fknm_c` object creation from a background thread"
+(an RTB-side mechanism that doesn't actually apply here -- this repo has
+no `_fknm_c` involvement at all) and "daemon thread abandoned mid-frame
+at interpreter shutdown" (disproven directly: headless -- zero threads --
+never leaked; a fully graceful `close()` with no interruption still
+leaked; `gc.collect()` couldn't reclaim it even with `env`/`box` explicitly
+deleted, ruling out a plain abandoned-thread or reference-cycle
+explanation).
+
+### Actual root cause
+
+`SwiftServer`'s HTTP thread (`SwiftRoute.py`) called `httpd.serve_forever()`
+but nothing ever called `httpd.shutdown()` -- so that thread ran for the
+rest of the process's life, regardless of `close()`. `threading.Thread.run()`
+only clears the arguments it was started with (`self._target`/`_args`/
+`_kwargs`) *after* the target function returns -- since `serve_forever()`
+never returned, the wrapping `Thread` object kept those arguments alive
+forever, one of which is a bound method of the `Swift` instance itself
+(`self._servers_running`, passed as `run` to both `SwiftSocket` *and*
+`SwiftServer`). That single un-cleared reference kept the entire `env`
+alive -- `swift_objects` (every shape ever added), and so every shape's
+`_Node`, for the process's whole lifetime, regardless of whether `close()`
+had been called or how gracefully.
+
+This is not a `nanobind`/`spatialgeometry` bug -- nanobind's leak report
+was accurate the whole time; the object genuinely was still alive and
+reachable from a live thread's own retained call arguments, which is
+exactly the case `gc` correctly refuses to collect (it isn't garbage).
+
+Confirmed via a real (non-mocked) repro: `env.server_thread.is_alive()`
+stayed `True` indefinitely after `close()` returned; `gc.get_referrers()`
+on the leaked object traced straight back through `env.__dict__` to the
+bound-method arguments retained by the never-finished `Thread.run()` call.
+
+Separately, `SwiftSocket`'s own thread (the websocket side) does
+terminate correctly -- `producer()`'s `self.outq.get()` is a genuine
+blocking (non-`await`ed) `queue.Queue.get()` inside an `async def`, which
+blocks the whole event-loop thread for however long it takes the next
+`outq` item to arrive (up to the full `join(1)` timeout in the worst
+case) -- a real, separate inefficiency worth fixing (e.g. a sentinel
+value or switching to `asyncio.Queue`), but not the leak's cause.
+
+### Fix
+
+`SwiftServer` now stores `self.httpd` and exposes a `stop()` method
+(`self.httpd.shutdown()`), mirroring `SwiftSocket.stop()`. `start_servers()`
+now returns the actual `SwiftServer` instance (not just the wrapping
+`Thread`), the same pattern already used for `SwiftSocket`. `Swift.
+_stop_threads()` calls `self.server.stop()` before joining
+`self.server_thread`. Verified fixed via the same repro: `_Node` no
+longer appears in nanobind's leak report, `env` is reclaimed by a single
+`gc.collect()` pass after `del env, box`, and both threads report
+`is_alive() == False` after `close()` returns.
 
 ---
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -421,6 +421,31 @@ def test_start_servers_socket_thread_actually_stops_on_close():
     assert not t.is_alive(), "SwiftSocket's thread did not actually stop"
 
 
+def test_start_servers_http_thread_actually_stops_on_close():
+    # Regression test for the nanobind _Node leak (tech-debt.md,
+    # 2026-08-02): SwiftServer's httpd.serve_forever() never returned
+    # (nothing ever called httpd.shutdown()), so Thread.run() never
+    # reached its own cleanup of the arguments it was started with --
+    # one of which is a bound method of the Swift instance, keeping
+    # every shape ever added alive for the process's whole life,
+    # regardless of close(). Exercises the real SwiftServer/httpd, not a
+    # mock -- a FakeBrowser-based test can't see a thread that's still
+    # running after the test function returns.
+    from swift.SwiftRoute import SwiftServer
+
+    outq, inq = Queue(), Queue()
+    t = threading.Thread(
+        target=SwiftServer, args=(outq, inq, 0, lambda: True), daemon=True
+    )
+    t.start()
+    port, instance = inq.get(timeout=5)
+
+    instance.stop()
+
+    t.join(timeout=3)
+    assert not t.is_alive(), "SwiftServer's thread did not actually stop"
+
+
 def test_hold_duration_returns_even_while_still_connected(monkeypatch):
     # Regression test: hold(5) used to map its positional arg to timeout=
     # (a grace period that only starts counting AFTER a disconnect), so a


### PR DESCRIPTION
## Summary
- Root-causes and fixes the \`nanobind: leaked N instances!\` warning seen on every non-headless Swift session -- previously misdiagnosed twice (an RTB-side fknm theory, then a daemon-thread-abandonment theory, both ruled out this session).
- Actual cause: \`SwiftServer\`'s HTTP thread ran \`httpd.serve_forever()\` but nothing ever called \`httpd.shutdown()\`. Since it never returned, \`Thread.run()\` never reached its own cleanup of its start arguments -- one of which is a bound method of the \`Swift\` instance itself, keeping every shape ever added alive for the process's entire life regardless of \`close()\`.
- \`SwiftServer\` now exposes \`stop()\` (mirroring \`SwiftSocket.stop()\`), \`start_servers()\` returns the real instance instead of just the wrapping \`Thread\`, and \`Swift._stop_threads()\` calls it before joining.
- Full writeup in \`tech-debt.md\`.

## Test plan
- [x] New real (non-mocked) regression test: \`test_start_servers_http_thread_actually_stops_on_close\`
- [x] Full suite: 66/66 passing
- [x] Verified via a real repro: leaked object no longer reported by nanobind, \`env\` reclaimed by a single \`gc.collect()\` after \`del env, box\`, both server threads report \`is_alive() == False\` after \`close()\`
- [x] Confirmed end-to-end against \`examples/two_link_arm.py\`, which previously printed the leak warning on every run and no longer does