### PR TITLE
fix: hold()/run() never noticed a browser disconnect while idle

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,4 +5,5 @@ Swift
    :maxdepth: 2
 
    intro
+   internals
    api

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -1,0 +1,251 @@
+*********
+Internals
+*********
+
+This page explains what actually happens underneath ``env.launch()`` --
+threads, sockets, queues, and the wire protocol. Nothing here is public
+API; it exists so anyone extending Swift or chasing a bug doesn't have to
+rediscover the architecture from scratch (which is exactly how this page
+came to be written).
+
+
+Processes, threads, and where they live
+========================================
+
+A non-headless session is **one Python process**, **one browser tab**,
+and **three threads** inside the Python process:
+
+.. code-block:: text
+
+    Python process (your script)
+    │
+    ├── Main thread
+    │     runs your script: add_shape(), step(), hold(), ...
+    │     owns outq / inq (see below)
+    │
+    ├── SwiftServer thread (daemon)
+    │     a socketserver.ThreadingTCPServer serving static files
+    │     (swift/public/*) and the "/retrieve/<path>" passthrough
+    │     route for local mesh files -- plain HTTP, port 52000+
+    │
+    └── SwiftSocket thread (daemon)
+          owns its own asyncio event loop (asyncio.new_event_loop() +
+          run_forever()) running a websockets server -- port 53000+
+          this is where the real-time protocol lives
+
+                                    ▲
+                                    │ WebSocket (SwiftSocket)
+                                    │ HTTP, once, for the initial
+                                    │ page load (SwiftServer)
+                                    ▼
+                              Browser tab
+                        (public/js/*.js, three.js)
+
+Two separate servers, two separate ports, on purpose: the HTTP server's
+job (serve ``index.html``/JS/vendor files once, then serve occasional
+``/retrieve/<path>`` mesh requests) is completely different traffic from
+the WebSocket's job (a continuous, low-latency, bidirectional message
+stream for every shape update, every step, every UI interaction). Mixing
+them onto one server/port would work, but there's no reason to couple
+two unrelated concerns.
+
+Both background threads are daemon threads, but that alone does **not**
+mean they exit when your script does -- see `Shutdown`_ below. Getting
+this wrong (before it was fixed) is exactly what caused the
+``tech-debt.md``-documented nanobind leak: a thread that never
+terminates keeps everything it can reach alive for the rest of the
+process's life, GC or no GC.
+
+
+The wire protocol
+==================
+
+``self.outq`` / ``self.inq`` (both a plain thread-safe ``queue.Queue``)
+are the *only* channel between the main thread and ``SwiftSocket``'s
+event-loop thread. Everything crosses through them -- there is no other
+shared state.
+
+- **``outq``**: Python → browser. ``Swift._send_socket(code, data,
+  expected=True)`` puts ``(expected, (code, data))`` onto ``outq``.
+  ``SwiftSocket.producer()`` (running on the event-loop thread) takes it
+  off, JSON-encodes it, and sends it over the WebSocket.
+- **``inq``**: browser → Python. Every reply from the browser (and the
+  very first message of the initial handshake) gets put onto ``inq``.
+  If ``expected=True``, ``_send_socket()`` blocks on ``inq.get(timeout=
+  _REPLY_TIMEOUT)`` (15s) waiting for it; ``expected=False`` is
+  fire-and-forget (e.g. per-step pose updates that don't need
+  acknowledgement).
+
+A message is always ``[code, data]`` -- a short string identifying what
+it is, plus a JSON-serialisable payload. ``main.js``'s ``onMessage``
+switch statement is the browser-side source of truth for every ``code``
+that exists; there is no other protocol spec. A few worth knowing by
+name:
+
+- ``"shape"`` -- add an object (a flat list of per-part dicts, one
+  entry per link for a robot, one entry total for a lone shape). Reply:
+  the new object's id.
+- ``"shape_mounted"`` -- poll whether an object finished loading in the
+  browser (see `Loading and the shape_mounted protocol`_ below).
+- ``"shape_poses"`` -- the per-step batch pose update every
+  :meth:`~swift.Swift.Swift.step` call sends.
+- ``"element"`` -- add a UI element (:class:`~swift.SwiftElement.SwiftElement`
+  subclass).
+- ``"close"`` -- sent once, right before the Python side tears its
+  threads down (see `Shutdown`_).
+
+
+Loading and the ``shape_mounted`` protocol
+============================================
+
+Adding a shape/robot is two round trips, not one: the ``"shape"``
+message hands the browser a part list and gets back an id immediately
+(construction is synchronous), but *loading* each part's actual asset
+(a mesh file, or building primitive/``Axes``/``Arrow`` geometry) happens
+asynchronously in the browser. :meth:`~swift.Swift.Swift._wait_mounted`
+polls ``"shape_mounted"`` in a loop until it's done:
+
+.. code-block:: text
+
+    reply = [code, detail]
+
+    code ==  1   mounted -- stop polling, return
+    code ==  0   still loading -- sleep 0.1s, poll again
+    code == -1   unsupported shape type -- raise RuntimeError(detail)
+    code == -2   asset/mesh load failed -- raise RuntimeError(detail)
+
+``detail`` is the browser's own diagnostic string (e.g. ``"unsupported
+shape type 'axes'"``, or the underlying loader error for a bad mesh
+path) -- it travels back over the wire specifically so the Python-side
+exception can say exactly what went wrong, rather than a generic
+"check the browser's JavaScript console" (which used to be the only
+option; see ``shapes.js``'s ``load()``/``SwiftObject`` for where ``code``
+and ``detail`` actually get decided).
+
+
+Connection lifecycle
+======================
+
+1. ``launch()`` starts both background threads (``start_servers()``),
+   opens (or displays a link/iframe for) the browser tab, and blocks on
+   the initial handshake (``inq.get(timeout=handshake_timeout)``) --
+   this is the "Could not connect to the Swift simulator" timeout if
+   nothing ever connects.
+2. Once connected, ``launch()`` sends the initial ``axes``/
+   ``ground_opacity``/``browser_timeout`` state and adds the built-in
+   pause/realtime-speed controls.
+3. Your script runs -- ``add_shape()``/``add_robot()``/``step()``/
+   ``hold()``/``run()`` etc., all going through ``outq``/``inq``.
+4. Something ends the session -- see `Shutdown`_.
+
+
+Disconnect detection
+======================
+
+``SwiftSocket.USERS`` is a ``set`` of currently-connected websocket
+objects (really just 0 or 1 in normal use -- one browser tab).
+:meth:`~swift.Swift.Swift.hold`/:meth:`~swift.Swift.Swift.run` poll
+``len(self.socket.USERS) > 0`` once a second to decide whether the
+browser is still there.
+
+Getting ``USERS`` cleaned up *promptly* when the tab actually closes
+took real work, and is worth understanding if you're ever debugging
+something in this area again. ``SwiftSocket.serve()``'s per-connection
+loop is, conceptually:
+
+.. code-block:: python
+
+    while self.run():
+        message = await self.producer()   # next thing to send
+        await websocket.send(json.dumps(message))
+        await self.expect_message(websocket, expected)
+
+The naive version of ``producer()`` is a **blocking**
+``self.outq.get()`` -- fine when something is actively being sent every
+frame (:meth:`step`), but during a plain :meth:`hold` with nothing
+actively stepping, *nothing is ever queued*. A blocking call inside an
+``async def``, with nothing to wait on, doesn't just block that one
+coroutine -- since asyncio is cooperative and single-threaded per event
+loop, it blocks the *entire event loop*, so nothing else on that loop
+(including noticing the browser disconnected) gets a chance to run
+either. The fix has two parts, both necessary:
+
+1. ``producer()`` runs the blocking ``outq.get()`` via
+   ``asyncio.to_thread()`` instead of calling it directly -- this makes
+   the *await* itself non-blocking, freeing the event loop while
+   nothing is queued.
+2. That alone isn't sufficient -- nothing was *watching* the connection
+   for closure either way. ``serve()``'s loop now races ``producer()``
+   against ``websocket.wait_closed()`` (``asyncio.wait(...,
+   return_when=FIRST_COMPLETED)``); whichever resolves first wins. A
+   disconnect now gets noticed the moment it happens, not just the next
+   time ``serve()`` happens to actively send/recv (which, during an idle
+   :meth:`hold`, might be never).
+
+One more subtlety: cancelling the ``producer()`` task when
+``wait_closed()`` wins does **not** stop the underlying blocking
+``outq.get()`` already running on its ``to_thread()`` worker --
+``queue.Queue`` has no cancellation hook. Left alone, that thread sits
+blocked forever, and since ``to_thread()``'s workers are deliberately
+**non-daemon** (so work is never silently abandoned), it would keep the
+whole *process* alive indefinitely, even after your script has
+otherwise finished. The fix pushes a throwaway sentinel value into
+``outq`` right before cancelling, unblocking the orphaned ``.get()`` the
+same way a real message would.
+
+Once ``USERS`` is empty, :meth:`hold`/:meth:`run` see it on their next
+1-second poll, wait out ``timeout`` (see the table in
+:meth:`~swift.Swift.Swift.launch`'s docstring), print ``"Swift browser
+tab closed."``, and call :meth:`~swift.Swift.Swift.close`.
+
+
+Shutdown
+=========
+
+:meth:`~swift.Swift.Swift.close` (called explicitly, or automatically by
+:meth:`hold`/:meth:`run` on a disconnect-timeout or ``^C``) does three
+things:
+
+1. ``self._send_socket("close", "0", False)`` -- tell the browser it's
+   over (fire-and-forget).
+2. ``self.socket.stop()`` -- ``self.loop.call_soon_threadsafe(self.loop
+   .stop)``, from the calling thread, since ``run_forever()`` is
+   executing on a *different* thread than whichever one calls
+   :meth:`close`.
+3. ``self.server.stop()`` -- ``self.httpd.shutdown()``. Easy to assume
+   this doesn't matter ("it's just a static file server, it isn't
+   holding anything interesting") -- it was, in fact, exactly what was
+   keeping every shape ever added alive for the rest of the process's
+   life. ``socketserver.BaseServer.serve_forever()`` never returns on
+   its own; nothing ever called ``shutdown()`` before this fix.
+   ``threading.Thread.run()`` only clears the arguments it was started
+   with (``self._target``/``_args``/``_kwargs``) *after* the target
+   function returns -- since ``serve_forever()`` never returned, the
+   wrapping ``Thread`` object kept those start arguments alive forever.
+   One of them is a bound method of the ``Swift`` instance itself
+   (``self._servers_running``, passed as the ``run`` callback to *both*
+   ``SwiftSocket`` and ``SwiftServer``) -- so that single, easy-to-miss
+   reference kept the whole environment (every shape, every scene-graph
+   node) alive indefinitely, regardless of how gracefully everything
+   else shut down. See ``tech-debt.md``'s "``spatialgeometry.scene._Node``
+   nanobind leak" entry for the full investigation.
+
+Both ``.stop()`` calls are followed by a bounded ``.join(1)`` in
+``_stop_threads()`` -- by design a best-effort wait, not a guarantee;
+a still-running thread after ``close()`` returns is itself worth
+investigating rather than assuming is fine.
+
+
+Where to look next
+====================
+
+- ``tech-debt.md`` (repo root) -- the incident log behind most of the
+  above: what broke, how it was found, exact fixes. This page is the
+  steady-state architecture; that file is the history of getting here.
+- ``src/swift/SwiftRoute.py`` -- ``SwiftSocket``/``SwiftServer``,
+  ``start_servers()``.
+- ``src/swift/public/js/main.js`` -- the browser-side ``onMessage``
+  switch statement, the actual protocol source of truth.
+- ``src/swift/public/js/shapes.js`` -- per-shape loading/rendering,
+  ``SwiftObject``, the ``load()``/error-code logic behind
+  ``shape_mounted``.

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -249,13 +249,40 @@ class Swift:
         ``env = launch(args)`` create a 3D scene in a running Swift instance as
         defined by args, and returns a reference to the backend.
 
-        ``timeout`` and ``browser_timeout`` cover two different halves of
-        the same disconnect: ``timeout`` is how long this Python process
-        (specifically :meth:`hold`) keeps waiting once it notices the
-        browser is gone; ``browser_timeout`` is how long the browser tab
-        itself waits once it notices *this process* is gone before
-        closing itself. Neither one can observe the other's side of a
-        disconnect directly, so both exist and are set independently.
+        ``timeout`` and ``browser_timeout`` cover two independent,
+        opposite-direction halves of the same disconnect -- worth
+        spelling out in full, since the two are easy to mix up:
+
+        ========================  ================================  ================================
+        Parameter                 *Who* is waiting                   *For what*
+        ========================  ================================  ================================
+        ``timeout``                This Python process, inside        The browser tab to still be there
+                                    :meth:`hold`/:meth:`run`
+        ``browser_timeout``        The browser tab (JavaScript)       This Python process to still be
+                                                                       alive
+        ========================  ================================  ================================
+
+        Concretely:
+
+        * Close the **browser tab** -- ``timeout`` (default 1 second) is
+          how long :meth:`hold`/:meth:`run` keep polling before giving
+          up, printing ``"Swift browser tab closed."``, calling
+          :meth:`close`, and returning. Actual wall-clock latency is
+          ``timeout`` plus up to ~1 second of polling granularity --
+          about 2 seconds with the default.
+        * Kill **this Python process** (or it crashes) -- ``browser_timeout``
+          (default 5 seconds) is how long the browser tab waits before
+          closing itself. Python can't run any code to reconnect a dead
+          process, so this side needs its own, independently-configured
+          timer running entirely in the browser.
+
+        Neither side can observe the other's half of a disconnect
+        directly -- the browser can't poll a dead Python process, and a
+        killed Python process can't run any code at all -- which is why
+        two separate parameters exist rather than one. Either can be set
+        to ``None`` for "wait forever" on that side. See
+        :doc:`internals` for the full mechanism (threads, sockets,
+        exactly what "the browser is gone" means internally).
 
         :param realtime: Force the simulator to display no faster than real
             time, note that it may still run slower due to complexity.

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -173,7 +173,7 @@ class Swift:
         # How long hold() keeps waiting after the browser disconnects
         # before giving up -- see launch()'s timeout= and hold(). None
         # means wait forever (the old behaviour).
-        self._hold_timeout = 5
+        self._hold_timeout = 1
         # How long the *browser tab* waits after losing its connection to
         # this Python process before closing itself -- see launch()'s
         # browser_timeout=. None means never auto-close. Independent of
@@ -239,7 +239,7 @@ class Swift:
         browser: str | None = None,
         axes: bool = True,
         ground_opacity: float = 1.0,
-        timeout: float | None = 5,
+        timeout: float | None = 1,
         browser_timeout: float | None = 5,
         **kwargs,
     ):
@@ -283,7 +283,7 @@ class Swift:
         :param timeout: how long :meth:`hold` keeps waiting, in seconds,
             after the browser tab disconnects before giving up and
             returning. ``None`` means wait indefinitely (the pre-2.1
-            behaviour), defaults to 5
+            behaviour), defaults to 1
         :type timeout: float | None
         :param browser_timeout: how long the *browser tab* waits, in
             seconds, after losing its connection to this process before
@@ -846,7 +846,7 @@ class Swift:
         :type duration: float | None
         :param timeout: seconds to keep waiting after the browser
             disconnects before giving up and returning early; defaults
-            to whatever :meth:`launch` was given (itself 5 by default).
+            to whatever :meth:`launch` was given (itself 1 by default).
             ``None`` never gives up on a disconnect (still stops at
             ``duration``, if given).
         :type timeout: float | None
@@ -863,6 +863,8 @@ class Swift:
                 time.sleep(1)
                 disconnected_since, expired = self._check_disconnected(disconnected_since, timeout)
                 if expired:
+                    print("\nSwift browser tab closed.")
+                    self.close()
                     return
         except KeyboardInterrupt:
             # ^C is the normal, expected way to end an interactive session
@@ -919,7 +921,7 @@ class Swift:
         :type dt: float
         :param timeout: seconds to keep running after the browser
             disconnects before giving up and returning; defaults to
-            whatever :meth:`launch` was given (itself 5 by default).
+            whatever :meth:`launch` was given (itself 1 by default).
             ``None`` never gives up on a disconnect (still stops at
             ``duration``, if given).
         :type timeout: float | None
@@ -937,6 +939,8 @@ class Swift:
                 time.sleep(dt)
                 disconnected_since, expired = self._check_disconnected(disconnected_since, timeout)
                 if expired:
+                    print("\nSwift browser tab closed.")
+                    self.close()
                     return
         except KeyboardInterrupt:
             # ^C is the normal, expected way to end an interactive session

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -209,7 +209,37 @@ class SwiftSocket:
 
             # Now onto send, recieve cycle
             while self.run():
-                message = await self.producer()
+                # producer() can wait a long time (nothing queued during a
+                # plain hold() with nothing actively step()-ing) -- racing
+                # it against wait_closed() means a disconnect gets noticed
+                # even while idle, instead of only the next time this code
+                # actively tries to send/recv (which, during an idle
+                # hold(), might be never). Without this, USERS never gets
+                # cleaned up for an idle connection, which silently
+                # defeats hold()'s own disconnect-timeout polling.
+                producer_task = asyncio.ensure_future(self.producer())
+                closed_task = asyncio.ensure_future(websocket.wait_closed())
+                done, _ = await asyncio.wait(
+                    [producer_task, closed_task], return_when=asyncio.FIRST_COMPLETED
+                )
+                if closed_task in done:
+                    producer_task.cancel()
+                    # Cancelling the *await* doesn't stop the underlying
+                    # blocking self.outq.get() call already running on its
+                    # own worker thread (queue.Queue has no cancellation
+                    # hook) -- left alone, that thread sits blocked
+                    # forever, and since asyncio.to_thread()'s workers are
+                    # deliberately non-daemon (stdlib default, to avoid
+                    # silently abandoning work), it would keep the whole
+                    # process alive indefinitely even after this script
+                    # has otherwise finished. A throwaway value unblocks
+                    # it the same way a real message would; nothing is
+                    # left to consume the result, so its value doesn't
+                    # matter.
+                    self.outq.put((False, ("__disconnect_sentinel__", None)))
+                    raise websockets.exceptions.ConnectionClosed(None, None)
+                closed_task.cancel()
+                message = producer_task.result()
                 expected = message[0]
                 msg = message[1]
                 await websocket.send(json.dumps(msg))

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -230,8 +230,18 @@ class SwiftSocket:
             self.inq.put(recieved)
 
     async def producer(self):
-        data = self.outq.get()
-        return data
+        # self.outq.get() is a genuine blocking call (a plain thread-safe
+        # queue.Queue, shared with the synchronous Python-thread side --
+        # can't just swap in asyncio.Queue without breaking that side's
+        # ordinary .put()/.get()). Awaiting it directly here would block
+        # this whole event-loop thread for however long nothing's queued
+        # -- which is most of the time during a plain hold() with nothing
+        # actively step()-ing -- starving the loop of any chance to notice
+        # the underlying connection closed. asyncio.to_thread() runs the
+        # blocking .get() on a worker thread and genuinely suspends this
+        # coroutine while waiting, so the event loop stays free to detect
+        # a closed connection (and cancel this await) in the meantime.
+        return await asyncio.to_thread(self.outq.get)
 
 
 class SwiftServer:

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -1,5 +1,55 @@
 # Technical Debt
 
+## `hold()` never noticed a browser disconnect while idle -- fixed 2026-08-02
+
+Found live-testing the new `Axes`/`Arrow` rendering: kill the browser tab
+while sitting in a plain `env.hold()` (nothing actively `step()`-ing), and
+nothing happens -- no reaction even after 20+ seconds, requiring a manual
+^C. This despite `hold()`'s own disconnect-timeout mechanism (PR #71/#75,
+polling `SwiftSocket.USERS`) already existing and working correctly in
+principle.
+
+Root cause: `serve()`'s per-connection loop is `while self.run(): message
+= await self.producer()`, and `producer()` was a plain blocking
+`self.outq.get()` inside an `async def`. During an idle `hold()` nothing
+is ever queued, so `producer()` never returns -- meaning `serve()` never
+reaches its `except ConnectionClosed`/`finally: self.USERS.discard(...)`,
+so `USERS` never gets cleaned up, so `hold()`'s `len(self.socket.USERS) >
+0` check never sees it as empty. The disconnect-polling mechanism was
+correct; it just never got fed the information it needed, for the single
+most common usage pattern (add shapes, then just `hold()`).
+
+**Fixed in two steps, both needed:**
+1. `producer()` now does `await asyncio.to_thread(self.outq.get)` instead
+   of blocking directly -- keeps the event loop itself responsive. Alone,
+   this fixes nothing about *this* bug (nothing is watching the
+   connection for closure regardless of whether the loop is blocked or
+   not) -- confirmed by testing: still hung past 2 minutes with only this
+   change.
+2. `serve()`'s loop now races `producer()` against `websocket.
+   wait_closed()` (`asyncio.wait(..., return_when=FIRST_COMPLETED)`) --
+   whichever resolves first wins. A disconnect now gets noticed even
+   while producer() is idle, not just the next time `serve()` happens to
+   actively send/recv.
+
+**A third, subtler issue found verifying the fix**: cancelling
+`producer_task` when `wait_closed()` wins doesn't stop the underlying
+blocking `self.outq.get()` call already running on its own
+`asyncio.to_thread()` worker -- `queue.Queue` has no cancellation hook.
+Left alone, that thread sits blocked forever and, since `to_thread()`'s
+workers are deliberately non-daemon (stdlib default), keeps the whole
+Python process alive indefinitely even after the script has otherwise
+finished -- caught because the repro script never exited after `hold()`
+returned and printed its result. Fixed by pushing a throwaway sentinel
+into `outq` right before cancelling, unblocking the orphaned `.get()` the
+same way a real message would.
+
+Verified via a real (non-mocked) repro: a scripted client connects, waits
+past `add_shape()`, then disconnects with nothing ever queued -- `hold()`
+now returns in ~8s (vs. hanging past 2 minutes before either fix), and
+the process now exits cleanly afterward. New test:
+`test_swift_socket_notices_disconnect_even_while_idle`.
+
 ## `shapes.js` mesh loading: `.obj`/`.gltf`/`.glb`/`.ply` skip the local-file proxy `.dae`/`.stl` use
 
 Found 2026-07-31, as a byproduct of checking whether `sg.Mesh()` can load

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -446,6 +446,56 @@ def test_start_servers_http_thread_actually_stops_on_close():
     assert not t.is_alive(), "SwiftServer's thread did not actually stop"
 
 
+def test_swift_socket_notices_disconnect_even_while_idle():
+    # Regression test: serve()'s while-loop calls producer(), which used to
+    # be a plain blocking self.outq.get() inside an async def -- during a
+    # plain hold() with nothing actively step()-ing, nothing is ever queued,
+    # so producer() (and so serve()) never returned control, so a
+    # disconnect was never noticed and USERS never got cleaned up. This
+    # silently defeated hold()'s own disconnect-timeout polling (self.socket
+    # .USERS) for the single most common usage pattern -- add shapes, then
+    # just hold() with no active stepping. Exercises a real client
+    # connecting and disconnecting with nothing ever queued in outq at all,
+    # mirroring exactly that idle-hold() scenario.
+    import asyncio
+    import time
+
+    import websockets
+
+    from swift.SwiftRoute import SwiftSocket
+
+    outq, inq = Queue(), Queue()
+    t = threading.Thread(
+        target=SwiftSocket, args=(outq, inq, lambda: True), daemon=True
+    )
+    t.start()
+    port, instance = inq.get(timeout=5)
+
+    def client_thread():
+        async def client():
+            async with websockets.connect(f"ws://localhost:{port}/") as ws:
+                await ws.send("Connected")
+                await asyncio.sleep(0.3)
+                # Exiting this block closes the connection -- nothing was
+                # ever queued in outq, so this is the idle-hold() case.
+
+        asyncio.run(client())
+
+    ct = threading.Thread(target=client_thread, daemon=True)
+    ct.start()
+    ct.join(timeout=5)
+
+    for _ in range(50):
+        if len(instance.USERS) == 0:
+            break
+        time.sleep(0.1)
+
+    assert len(instance.USERS) == 0, (
+        "SwiftSocket.USERS was never cleaned up after an idle disconnect "
+        "-- hold()'s disconnect-timeout polling would never fire"
+    )
+
+
 def test_hold_duration_returns_even_while_still_connected(monkeypatch):
     # Regression test: hold(5) used to map its positional arg to timeout=
     # (a grace period that only starts counting AFTER a disconnect), so a

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -311,6 +311,8 @@ def test_hold_returns_once_disconnected_past_timeout(monkeypatch):
     env.headless = False
     env.socket = SimpleNamespace(USERS=set())  # already disconnected
     env._hold_timeout = 2
+    closed = []
+    env.close = lambda *a, **kw: closed.append(True)
 
     fake_now = [0.0]
     monkeypatch.setattr(swift_module.time, "time", lambda: fake_now[0])
@@ -318,6 +320,7 @@ def test_hold_returns_once_disconnected_past_timeout(monkeypatch):
 
     env.hold()  # returns once disconnected for > 2s -- would hang otherwise
     assert fake_now[0] > 2
+    assert closed == [True]  # hold() now closes on a disconnect-timeout, not just ^C
 
 
 def test_hold_keeps_waiting_while_still_connected(monkeypatch):
@@ -327,6 +330,7 @@ def test_hold_keeps_waiting_while_still_connected(monkeypatch):
     env.headless = False
     env.socket = SimpleNamespace(USERS={"a-connected-browser"})
     env._hold_timeout = 1
+    env.close = lambda *a, **kw: None  # disconnects near the end, hold() closes
 
     call_count = [0]
 


### PR DESCRIPTION
## Summary

Killing the browser tab while sitting in a plain `env.hold()` (nothing
actively `step()`-ing) previously went unnoticed for 20s+ (in some cases,
minutes) instead of being detected promptly. Root-caused to two compounding
bugs in `SwiftRoute.py`'s `SwiftSocket`, plus a stale default in `Swift.py`:

- `producer()` blocked directly on `self.outq.get()` inside an `async def`,
  monopolizing the event loop — nothing else (including disconnect
  detection) could run while idle. Fixed via `asyncio.to_thread()`.
- Even with the loop responsive, nothing was actually watching the
  connection for closure while idle — `serve()`'s loop now races
  `producer()` against `websocket.wait_closed()`.
- `launch()`'s own `timeout` parameter default was still `5`, silently
  overriding `_init()`'s already-reduced `_hold_timeout = 1` on every real
  call (virtually all usage, since nobody explicitly passes `timeout=`).
  Both now agree on `1`.
- `hold()`/`run()` now print `"Swift browser tab closed."` and call
  `close()` on the disconnect-timeout path (previously only happened on
  ^C) — fixes a recurrence of the nanobind/HTTP-thread leak fixed in #79
  for this specific exit path.

Also adds `docs/source/internals.rst` — a from-scratch writeup of the
threading/socket/wire-protocol architecture, and clarifies `launch()`'s
`timeout`/`browser_timeout` docstring with a who's-waiting-for-what table.

## Test plan

- [x] `pytest tests/` — 66 passed, including a new real (non-mocked)
      `SwiftSocket` + real `websockets.connect()` test asserting a client
      disconnect is noticed within ~5s even while nothing is queued.
- [x] Live-tested end-to-end: kill-to-`hold()`-return dropped from 2+
      minutes (broken) to ~2.5s.
- [x] `docs/source/internals.rst` builds clean via `sphinx-build -W --keep-going`.