### PR TITLE
feat: render Axes/Arrow, and make shape_mounted failures specific

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -1199,11 +1199,13 @@ class Swift:
         Block until the browser confirms every part of object ``id`` has
         finished loading (see shapes.js's ``SwiftObject``).
 
-        A "shape_mounted" reply of ``1`` means loaded, ``0`` means still
-        loading (poll again), and ``-1`` means at least one part's asset
-        failed to load in the browser (bad path, unsupported/corrupt mesh
-        format, ...) -- see ``shapes.js``'s ``onError`` handlers, which
-        report failure this way rather than leaving this loop to poll
+        A "shape_mounted" reply is ``[code, detail]`` (see shapes.js's
+        ``load()``/``SwiftObject``): ``[1, None]`` means loaded, ``[0,
+        None]`` means still loading (poll again), ``[-1, reason]`` means
+        the shape type itself isn't one ``load()`` recognises at all, and
+        ``[-2, reason]`` means a genuine asset load failure (bad path,
+        unsupported/corrupt mesh format). Either failure stops this loop
+        and raises with the browser's own reason instead of polling
         forever with no way to tell the caller why (bugs.md, Bug 2).
 
         :param id: the object's id, as returned by the preceding "shape"
@@ -1215,15 +1217,15 @@ class Swift:
         :type count: int
         """
         while True:
-            status = int(self._send_socket("shape_mounted", [id, count]))
+            status, detail = json.loads(self._send_socket("shape_mounted", [id, count]))
             if status == 1:
                 return
             if status == -1:
+                raise RuntimeError(f"Swift failed to load object {id}: {detail}")
+            if status == -2:
                 raise RuntimeError(
-                    f"Swift failed to load one or more assets for object "
-                    f"{id} -- check the browser's JavaScript console for "
-                    "details (common causes: a bad mesh file path, or an "
-                    "unsupported file format)"
+                    f"Swift failed to load object {id}: {detail} -- check "
+                    "the browser's JavaScript console for the full error"
                 )
             time.sleep(0.1)
 

--- a/src/swift/public/js/main.js
+++ b/src/swift/public/js/main.js
@@ -100,9 +100,13 @@ transport.onMessage((func, data) => {
     case "shape_mounted": {
       const [id, _count] = data;
       const obj = objects[id];
-      // -1 tells Swift.py's poll loop to stop and raise, rather than retry
-      // forever -- see SwiftObject.hasError() and Swift._wait_mounted().
-      transport.send(obj.hasError() ? -1 : obj.isMounted() ? 1 : 0);
+      // A non-zero code (-1 unsupported shape type, -2 asset/mesh load
+      // failed -- see shapes.js's load()) tells Swift.py's poll loop to
+      // stop and raise with the specific reason, rather than retry
+      // forever -- see SwiftObject.hasError()/errorCode()/errorReason()
+      // and Swift._wait_mounted().
+      const reply = obj.hasError() ? [obj.errorCode, obj.errorReason] : [obj.isMounted() ? 1 : 0, null];
+      transport.send(reply);
       break;
     }
     case "remove": {

--- a/src/swift/public/js/scene.js
+++ b/src/swift/public/js/scene.js
@@ -4,6 +4,7 @@
 
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { resizeLines } from "./shapes.js";
 
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
@@ -86,6 +87,7 @@ export function createScene() {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
     renderer.setSize(window.innerWidth, window.innerHeight);
+    resizeLines(window.innerWidth, window.innerHeight);
   });
 
   return { scene, camera, renderer, controls, axesHelper, groundMaterial };

--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -19,6 +19,9 @@ import { VRMLLoader } from "three/addons/loaders/VRMLLoader.js";
 import { PCDLoader } from "three/addons/loaders/PCDLoader.js";
 import { PLYLoader } from "three/addons/loaders/PLYLoader.js";
 import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { Line2 } from "three/addons/lines/Line2.js";
+import { LineGeometry } from "three/addons/lines/LineGeometry.js";
+import { LineMaterial } from "three/addons/lines/LineMaterial.js";
 
 const daeLoader = new ColladaLoader();
 const stlLoader = new STLLoader();
@@ -28,6 +31,21 @@ const vrmLoader = new VRMLLoader();
 const pcdLoader = new PCDLoader();
 const plyLoader = new PLYLoader();
 const gltfLoader = new GLTFLoader();
+
+// LineMaterial (used for Arrow's radius=0 shaft and, later, Path) renders
+// screen-space-width lines via a resolution uniform it needs kept in sync
+// with the canvas size -- unlike everything else here, it doesn't pick this
+// up automatically. scene.js's resize handler calls resizeLines() with the
+// new canvas size; every LineMaterial ever created gets its own resolution
+// updated in place (copying into a material's Vector2 doesn't establish a
+// live reference back to this one).
+const lineResolution = new THREE.Vector2(window.innerWidth, window.innerHeight);
+const lineMaterials = [];
+
+export function resizeLines(width, height) {
+  lineResolution.set(width, height);
+  for (const material of lineMaterials) material.resolution.copy(lineResolution);
+}
 
 function setPose(object3d, t, q) {
   object3d.position.set(t[0], t[1], t[2]);
@@ -55,6 +73,34 @@ function finish(part, mesh, scene, cb) {
   cb();
 }
 
+/**
+ * Frees GPU resources for anything `finish()` handed to a scene -- a plain
+ * THREE.Mesh (material/geometry directly on it), a helper with its own
+ * dispose() (AxesHelper, ArrowHelper), or one of this module's own
+ * multi-child Groups (Arrow's shaft+cone, Axes' three per-axis arrows --
+ * see makeArrow()/loadAxes(), which tag every child needing disposal onto
+ * userData.disposables since Group itself owns no geometry/material).
+ */
+function disposeChild(child) {
+  child.material?.dispose?.();
+  child.geometry?.dispose?.();
+  // LineMaterial instances (Arrow's radius=0 shaft) are tracked in
+  // lineMaterials so resizeLines() can keep their resolution uniform
+  // current -- forgetting to untrack here would leak one entry per Arrow
+  // ever created, for the life of the page.
+  const idx = lineMaterials.indexOf(child.material);
+  if (idx !== -1) lineMaterials.splice(idx, 1);
+}
+
+function disposeMesh(object) {
+  if (typeof object.dispose === "function") {
+    object.dispose();
+    return;
+  }
+  disposeChild(object);
+  for (const child of object.userData.disposables ?? []) disposeChild(child);
+}
+
 function loadPrimitive(part, scene, cb) {
   let geometry;
   if (part.stype === "cuboid" || part.stype === "box") {
@@ -67,6 +113,84 @@ function loadPrimitive(part, scene, cb) {
   const mesh = new THREE.Mesh(geometry, materialFor(part));
   setPose(mesh, part.t, part.q);
   finish(part, mesh, scene, cb);
+}
+
+/**
+ * spatialgeometry.Arrow: a shaft (cylinder if radius > 0, otherwise a
+ * screen-space-width line via LineMaterial) plus a cone head. radius and
+ * linewidth are mutually exclusive -- radius > 0 always wins, matching
+ * Arrow's own Python-side docstring.
+ *
+ * @param {number} color 0xRRGGBB
+ * @returns {THREE.Object3D} local +Z is the arrow's direction, tip at
+ *   `length` -- callers position/orient this however they need (setPose(),
+ *   or a parent group for Axes' per-axis rotation).
+ */
+function makeArrow(length, radius, linewidth, headLength, headRadius, color) {
+  const group = new THREE.Group();
+  const headLen = length * headLength;
+  const headWidth = headLen * headRadius;
+  const shaftLen = Math.max(0.0001, length - headLen);
+
+  let shaft;
+  if (radius > 0) {
+    const geometry = new THREE.CylinderGeometry(radius, radius, shaftLen, 16);
+    // CylinderGeometry is centred on Y with the app's default axis -- shift
+    // so the base sits at the origin, then rotate Y-up into Z-forward to
+    // match spatialgeometry's Arrow (+Z) convention.
+    geometry.translate(0, shaftLen / 2, 0);
+    geometry.rotateX(Math.PI / 2);
+    shaft = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ color, specular: 0x111111, shininess: 200 }));
+  } else {
+    const positions = [0, 0, 0, 0, 0, shaftLen];
+    const lineGeometry = new LineGeometry();
+    lineGeometry.setPositions(positions);
+    const material = new LineMaterial({ color, linewidth, worldUnits: false });
+    material.resolution.copy(lineResolution);
+    shaft = new Line2(lineGeometry, material);
+    lineMaterials.push(material); // kept in sync on resize -- see scene.js
+  }
+  group.add(shaft);
+
+  const coneGeometry = new THREE.ConeGeometry(headWidth / 2, headLen, 16);
+  coneGeometry.translate(0, headLen / 2, 0);
+  coneGeometry.rotateX(Math.PI / 2);
+  const cone = new THREE.Mesh(coneGeometry, new THREE.MeshPhongMaterial({ color, specular: 0x111111, shininess: 200 }));
+  cone.position.z = shaftLen;
+  group.add(cone);
+
+  group.userData.disposables = [shaft, cone];
+  return group;
+}
+
+function loadArrow(part, scene, cb) {
+  const arrow = makeArrow(part.length, part.radius, part.linewidth, part.head_length, part.head_radius, part.color);
+  setPose(arrow, part.t, part.q);
+  finish(part, arrow, scene, cb);
+}
+
+const _AXIS_COLORS = [0xff0000, 0x00ff00, 0x0000ff]; // X red, Y green, Z blue
+const _AXIS_ROTATIONS = [
+  new THREE.Euler(0, Math.PI / 2, 0), // +Z -> +X
+  new THREE.Euler(-Math.PI / 2, 0, 0), // +Z -> +Y
+  new THREE.Euler(0, 0, 0), // +Z -> +Z, no rotation needed
+];
+
+function loadAxes(part, scene, cb) {
+  let axes;
+  if (part.arrows) {
+    axes = new THREE.Group();
+    for (let i = 0; i < 3; i++) {
+      const arrow = makeArrow(part.length, part.radius, part.linewidth, 0.2, 0.2, _AXIS_COLORS[i]);
+      arrow.setRotationFromEuler(_AXIS_ROTATIONS[i]);
+      axes.add(arrow);
+    }
+    axes.userData.disposables = axes.children.flatMap((a) => a.userData.disposables);
+  } else {
+    axes = new THREE.AxesHelper(part.length);
+  }
+  setPose(axes, part.t, part.q);
+  finish(part, axes, scene, cb);
 }
 
 function loadMesh(part, scene, cb, errCb) {
@@ -89,8 +213,9 @@ function loadMesh(part, scene, cb, errCb) {
   // and Swift._wait_mounted() in Swift.py); a swallowed error here means
   // that poll spins forever with no way for the caller to find out why.
   const onError = (label) => (error) => {
-    console.error(`Error loading ${label} file`, error);
-    errCb();
+    const reason = `failed to load ${label} file '${part.filename}': ${error}`;
+    console.error(reason, error);
+    errCb(-2, reason);
   };
   const onProgress = (xhr) => {
     if (xhr.total) console.log(`${((xhr.loaded / xhr.total) * 100).toFixed(0)}% loaded`);
@@ -207,17 +332,21 @@ function loadMesh(part, scene, cb, errCb) {
       onError("PCD")
     );
   } else {
-    console.error(`Unsupported mesh extension: ${ext}`);
-    errCb();
+    const reason = `unsupported mesh extension '${ext}' (${part.filename})`;
+    console.error(reason);
+    errCb(-2, reason);
   }
 }
 
 function load(part, scene, cb, errCb) {
   if (part.stype === "mesh") loadMesh(part, scene, cb, errCb);
   else if (["cuboid", "box", "sphere", "cylinder"].includes(part.stype)) loadPrimitive(part, scene, cb);
+  else if (part.stype === "axes") loadAxes(part, scene, cb);
+  else if (part.stype === "arrow") loadArrow(part, scene, cb);
   else {
-    console.error(`Unsupported shape type: ${part.stype}`);
-    errCb();
+    const reason = `unsupported shape type '${part.stype}'`;
+    console.error(reason);
+    errCb(-1, reason);
   }
 }
 
@@ -237,12 +366,23 @@ export class SwiftObject {
     this.parts = parts;
     this.loaded = 0;
     this.failed = 0;
+    // First failure's code/reason -- see load()'s two error paths
+    // (-1 unsupported shape type, -2 asset/mesh load failed). Kept as
+    // the *first* one seen: with several parts, only one reason is ever
+    // surfaced to Swift.py's exception, and the first is the most
+    // actionable/deterministic choice.
+    this.errorCode = null;
+    this.errorReason = null;
 
     const cb = () => {
       this.loaded++;
     };
-    const errCb = () => {
+    const errCb = (code, reason) => {
       this.failed++;
+      if (this.errorCode === null) {
+        this.errorCode = code;
+        this.errorReason = reason;
+      }
     };
     for (const part of this.parts) load(part, scene, cb, errCb);
   }
@@ -251,7 +391,7 @@ export class SwiftObject {
     return this.loaded === this.parts.length;
   }
 
-  /** True once any part has failed to load -- see loadMesh()'s onError handlers. */
+  /** True once any part has failed to load -- see load()'s error paths. */
   hasError() {
     return this.failed > 0;
   }
@@ -267,8 +407,7 @@ export class SwiftObject {
   updatePart(index, partData) {
     const old = this.parts[index];
     if (old.mesh) {
-      old.mesh.material?.dispose?.();
-      old.mesh.geometry?.dispose?.();
+      disposeMesh(old.mesh);
       this.scene.remove(old.mesh);
       this.loaded--;
     }
@@ -279,8 +418,12 @@ export class SwiftObject {
       () => {
         this.loaded++;
       },
-      () => {
+      (code, reason) => {
         this.failed++;
+        if (this.errorCode === null) {
+          this.errorCode = code;
+          this.errorReason = reason;
+        }
       }
     );
   }
@@ -288,8 +431,7 @@ export class SwiftObject {
   remove(scene) {
     for (const part of this.parts) {
       if (!part.mesh) continue;
-      part.mesh.material?.dispose?.();
-      part.mesh.geometry?.dispose?.();
+      disposeMesh(part.mesh);
       scene.remove(part.mesh);
     }
   }

--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -129,7 +129,13 @@ function loadPrimitive(part, scene, cb) {
 function makeArrow(length, radius, linewidth, headLength, headRadius, color) {
   const group = new THREE.Group();
   const headLen = length * headLength;
-  const headWidth = headLen * headRadius;
+  // head_radius is a fraction of headLen and *is* the cone's base radius --
+  // not a diameter needing to be halved. Halving it here (an earlier bug)
+  // left the cone barely wider than the shaft for typical values, e.g.
+  // radius=0.01 with the 0.2/0.2 defaults produced a cone radius of only
+  // ~2x the shaft radius -- reads as "about the same width," not a
+  // recognisable arrowhead.
+  const headR = headLen * headRadius;
   const shaftLen = Math.max(0.0001, length - headLen);
 
   let shaft;
@@ -152,7 +158,7 @@ function makeArrow(length, radius, linewidth, headLength, headRadius, color) {
   }
   group.add(shaft);
 
-  const coneGeometry = new THREE.ConeGeometry(headWidth / 2, headLen, 16);
+  const coneGeometry = new THREE.ConeGeometry(headR, headLen, 16);
   coneGeometry.translate(0, headLen / 2, 0);
   coneGeometry.rotateX(Math.PI / 2);
   const cone = new THREE.Mesh(coneGeometry, new THREE.MeshPhongMaterial({ color, specular: 0x111111, shininess: 200 }));

--- a/src/swift/public/js/vendor/examples/jsm/lines/Line2.js
+++ b/src/swift/public/js/vendor/examples/jsm/lines/Line2.js
@@ -1,0 +1,56 @@
+import { LineSegments2 } from './LineSegments2.js';
+import { LineGeometry } from './LineGeometry.js';
+import { LineMaterial } from './LineMaterial.js';
+
+/**
+ * A polyline drawn between vertices.
+ *
+ * This adds functionality beyond {@link Line}, like arbitrary line width and changing width to
+ * be in world units.It extends {@link LineSegments2}, simplifying constructing segments from a
+ * chain of points.
+ *
+ * This module can only be used with {@link WebGLRenderer}. When using {@link WebGPURenderer},
+ * import the class from `lines/webgpu/Line2.js`.
+ *
+ * ```js
+ * const geometry = new LineGeometry();
+ * geometry.setPositions( positions );
+ * geometry.setColors( colors );
+ *
+ * const material = new LineMaterial( { linewidth: 5, vertexColors: true } };
+ *
+ * const line = new Line2( geometry, material );
+ * scene.add( line );
+ * ```
+ *
+ * @augments LineSegments2
+ * @three_import import { Line2 } from 'three/addons/lines/Line2.js';
+ */
+class Line2 extends LineSegments2 {
+
+	/**
+	 * Constructs a new wide line.
+	 *
+	 * @param {LineGeometry} [geometry] - The line geometry.
+	 * @param {LineMaterial} [material] - The line material.
+	 */
+	constructor( geometry = new LineGeometry(), material = new LineMaterial( { color: Math.random() * 0xffffff } ) ) {
+
+		super( geometry, material );
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isLine2 = true;
+
+		this.type = 'Line2';
+
+	}
+
+}
+
+export { Line2 };

--- a/src/swift/public/js/vendor/examples/jsm/lines/LineGeometry.js
+++ b/src/swift/public/js/vendor/examples/jsm/lines/LineGeometry.js
@@ -1,0 +1,157 @@
+import { LineSegmentsGeometry } from './LineSegmentsGeometry.js';
+
+/**
+ * A chain of vertices, forming a polyline.
+ *
+ * This is used in {@link Line2} to describe the shape.
+ *
+ * ```js
+ * const points = [
+ * 	new THREE.Vector3( - 10, 0, 0 ),
+ * 	new THREE.Vector3( 0, 5, 0 ),
+ * 	new THREE.Vector3( 10, 0, 0 ),
+ * ];
+ *
+ * const geometry = new LineGeometry();
+ * geometry.setFromPoints( points );
+ * ```
+ *
+ * @augments LineSegmentsGeometry
+ * @three_import import { LineLineGeometry2 } from 'three/addons/lines/LineGeometry.js';
+ */
+class LineGeometry extends LineSegmentsGeometry {
+
+	/**
+	 * Constructs a new line geometry.
+	 */
+	constructor() {
+
+		super();
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isLineGeometry = true;
+
+		this.type = 'LineGeometry';
+
+	}
+
+	/**
+	 * Sets the given line positions for this geometry.
+	 *
+	 * @param {Float32Array|Array<number>} array - The position data to set.
+	 * @return {LineGeometry} A reference to this geometry.
+	 */
+	setPositions( array ) {
+
+		// converts [ x1, y1, z1,  x2, y2, z2, ... ] to pairs format
+
+		const length = array.length - 3;
+		const points = new Float32Array( 2 * length );
+
+		for ( let i = 0; i < length; i += 3 ) {
+
+			points[ 2 * i ] = array[ i ];
+			points[ 2 * i + 1 ] = array[ i + 1 ];
+			points[ 2 * i + 2 ] = array[ i + 2 ];
+
+			points[ 2 * i + 3 ] = array[ i + 3 ];
+			points[ 2 * i + 4 ] = array[ i + 4 ];
+			points[ 2 * i + 5 ] = array[ i + 5 ];
+
+		}
+
+		super.setPositions( points );
+
+		return this;
+
+	}
+
+	/**
+	 * Sets the given line colors for this geometry.
+	 *
+	 * @param {Float32Array|Array<number>} array - The position data to set.
+	 * @return {LineGeometry} A reference to this geometry.
+	 */
+	setColors( array ) {
+
+		// converts [ r1, g1, b1,  r2, g2, b2, ... ] to pairs format
+
+		const length = array.length - 3;
+		const colors = new Float32Array( 2 * length );
+
+		for ( let i = 0; i < length; i += 3 ) {
+
+			colors[ 2 * i ] = array[ i ];
+			colors[ 2 * i + 1 ] = array[ i + 1 ];
+			colors[ 2 * i + 2 ] = array[ i + 2 ];
+
+			colors[ 2 * i + 3 ] = array[ i + 3 ];
+			colors[ 2 * i + 4 ] = array[ i + 4 ];
+			colors[ 2 * i + 5 ] = array[ i + 5 ];
+
+		}
+
+		super.setColors( colors );
+
+		return this;
+
+	}
+
+	/**
+	 * Setups this line segments geometry from the given sequence of points.
+	 *
+	 * @param {Array<Vector3|Vector2>} points - An array of points in 2D or 3D space.
+	 * @return {LineGeometry} A reference to this geometry.
+	 */
+	setFromPoints( points ) {
+
+		// converts a vector3 or vector2 array to pairs format
+
+		const length = points.length - 1;
+		const positions = new Float32Array( 6 * length );
+
+		for ( let i = 0; i < length; i ++ ) {
+
+			positions[ 6 * i ] = points[ i ].x;
+			positions[ 6 * i + 1 ] = points[ i ].y;
+			positions[ 6 * i + 2 ] = points[ i ].z || 0;
+
+			positions[ 6 * i + 3 ] = points[ i + 1 ].x;
+			positions[ 6 * i + 4 ] = points[ i + 1 ].y;
+			positions[ 6 * i + 5 ] = points[ i + 1 ].z || 0;
+
+		}
+
+		super.setPositions( positions );
+
+		return this;
+
+	}
+
+	/**
+	 * Setups this line segments geometry from the given line.
+	 *
+	 * @param {Line} line - The line that should be used as a data source for this geometry.
+	 * @return {LineGeometry} A reference to this geometry.
+	 */
+	fromLine( line ) {
+
+		const geometry = line.geometry;
+
+		this.setPositions( geometry.attributes.position.array ); // assumes non-indexed
+
+		// set colors, maybe
+
+		return this;
+
+	}
+
+}
+
+export { LineGeometry };

--- a/src/swift/public/js/vendor/examples/jsm/lines/LineMaterial.js
+++ b/src/swift/public/js/vendor/examples/jsm/lines/LineMaterial.js
@@ -1,0 +1,726 @@
+import {
+	ShaderLib,
+	ShaderMaterial,
+	UniformsLib,
+	UniformsUtils,
+	Vector2,
+} from 'three';
+
+UniformsLib.line = {
+
+	worldUnits: { value: 1 },
+	linewidth: { value: 1 },
+	resolution: { value: new Vector2() },
+	dashOffset: { value: 0 },
+	dashScale: { value: 1 },
+	dashSize: { value: 1 },
+	gapSize: { value: 1 } // todo FIX - maybe change to totalSize
+
+};
+
+ShaderLib[ 'line' ] = {
+
+	uniforms: UniformsUtils.merge( [
+		UniformsLib.common,
+		UniformsLib.fog,
+		UniformsLib.line
+	] ),
+
+	vertexShader:
+	/* glsl */`
+		#include <common>
+		#include <color_pars_vertex>
+		#include <fog_pars_vertex>
+		#include <logdepthbuf_pars_vertex>
+		#include <clipping_planes_pars_vertex>
+
+		uniform float linewidth;
+		uniform vec2 resolution;
+
+		attribute vec3 instanceStart;
+		attribute vec3 instanceEnd;
+
+		attribute vec3 instanceColorStart;
+		attribute vec3 instanceColorEnd;
+
+		#ifdef WORLD_UNITS
+
+			varying vec4 worldPos;
+			varying vec3 worldStart;
+			varying vec3 worldEnd;
+
+			#ifdef USE_DASH
+
+				varying vec2 vUv;
+
+			#endif
+
+		#else
+
+			varying vec2 vUv;
+
+		#endif
+
+		#ifdef USE_DASH
+
+			uniform float dashScale;
+			attribute float instanceDistanceStart;
+			attribute float instanceDistanceEnd;
+			varying float vLineDistance;
+
+		#endif
+
+		float trimSegmentAlpha( const in vec4 start, const in vec4 end ) {
+
+			// compute the interpolation factor needed to trim the segment so it terminates
+			// between the camera plane and the near plane
+
+			// conservative estimate of the near plane
+			float a = projectionMatrix[ 2 ][ 2 ]; // 3nd entry in 3th column
+			float b = projectionMatrix[ 3 ][ 2 ]; // 3nd entry in 4th column
+
+			// we need different nearEstimate formula for reversed and default depth buffer
+			// a is positive with a reversed depth buffer so it can be used for controlling the code flow
+			float nearEstimate = ( a > 0.0 ) ? ( - b / ( a + 1.0 ) ) : ( - 0.5 * b / a );
+
+			return ( nearEstimate - start.z ) / ( end.z - start.z );
+
+		}
+
+		void main() {
+
+			#ifdef USE_COLOR
+
+				vColor.xyz = ( position.y < 0.5 ) ? instanceColorStart : instanceColorEnd;
+
+			#endif
+
+			float aspect = resolution.x / resolution.y;
+
+			// camera space
+			vec4 start = modelViewMatrix * vec4( instanceStart, 1.0 );
+			vec4 end = modelViewMatrix * vec4( instanceEnd, 1.0 );
+
+			#ifdef USE_DASH
+
+				float lineDistanceStart = dashScale * instanceDistanceStart;
+				float lineDistanceEnd = dashScale * instanceDistanceEnd;
+
+			#endif
+
+			#ifdef WORLD_UNITS
+
+				worldStart = start.xyz;
+				worldEnd = end.xyz;
+
+			#else
+
+				vUv = uv;
+
+			#endif
+
+			// special case for perspective projection, and segments that terminate either in, or behind, the camera plane
+			// clearly the gpu firmware has a way of addressing this issue when projecting into ndc space
+			// but we need to perform ndc-space calculations in the shader, so we must address this issue directly
+			// perhaps there is a more elegant solution -- WestLangley
+
+			bool perspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 ); // 4th entry in the 3rd column
+
+			if ( perspective ) {
+
+				if ( start.z < 0.0 && end.z >= 0.0 ) {
+
+					float alpha = trimSegmentAlpha( start, end );
+					end.xyz = mix( start.xyz, end.xyz, alpha );
+
+					#ifdef USE_DASH
+
+						lineDistanceEnd = mix( lineDistanceStart, lineDistanceEnd, alpha );
+
+					#endif
+
+				} else if ( end.z < 0.0 && start.z >= 0.0 ) {
+
+					float alpha = trimSegmentAlpha( end, start );
+					start.xyz = mix( end.xyz, start.xyz, alpha );
+
+					#ifdef USE_DASH
+
+						lineDistanceStart = mix( lineDistanceEnd, lineDistanceStart, alpha );
+
+					#endif
+
+				}
+
+			}
+
+			#ifdef USE_DASH
+
+				vLineDistance = ( position.y < 0.5 ) ? lineDistanceStart : lineDistanceEnd;
+				vUv = uv;
+
+			#endif
+
+			// clip space
+			vec4 clipStart = projectionMatrix * start;
+			vec4 clipEnd = projectionMatrix * end;
+
+			// ndc space
+			vec3 ndcStart = clipStart.xyz / clipStart.w;
+			vec3 ndcEnd = clipEnd.xyz / clipEnd.w;
+
+			// direction
+			vec2 dir = ndcEnd.xy - ndcStart.xy;
+
+			// account for clip-space aspect ratio
+			dir.x *= aspect;
+			dir = normalize( dir );
+
+			#ifdef WORLD_UNITS
+
+				vec3 worldDir = normalize( end.xyz - start.xyz );
+				vec3 tmpFwd = normalize( mix( start.xyz, end.xyz, 0.5 ) );
+				vec3 worldUp = normalize( cross( worldDir, tmpFwd ) );
+				vec3 worldFwd = cross( worldDir, worldUp );
+				worldPos = position.y < 0.5 ? start: end;
+
+				// height offset
+				float hw = linewidth * 0.5;
+				worldPos.xyz += position.x < 0.0 ? hw * worldUp : - hw * worldUp;
+
+				// don't extend the line if we're rendering dashes because we
+				// won't be rendering the endcaps
+				#ifndef USE_DASH
+
+					// cap extension
+					worldPos.xyz += position.y < 0.5 ? - hw * worldDir : hw * worldDir;
+
+					// add width to the box
+					worldPos.xyz += worldFwd * hw;
+
+					// endcaps
+					if ( position.y > 1.0 || position.y < 0.0 ) {
+
+						worldPos.xyz -= worldFwd * 2.0 * hw;
+
+					}
+
+				#endif
+
+				// project the worldpos
+				vec4 clip = projectionMatrix * worldPos;
+
+				// shift the depth of the projected points so the line
+				// segments overlap neatly
+				vec3 clipPose = ( position.y < 0.5 ) ? ndcStart : ndcEnd;
+				clip.z = clipPose.z * clip.w;
+
+			#else
+
+				vec2 offset = vec2( dir.y, - dir.x );
+				// undo aspect ratio adjustment
+				dir.x /= aspect;
+				offset.x /= aspect;
+
+				// sign flip
+				if ( position.x < 0.0 ) offset *= - 1.0;
+
+				// endcaps
+				if ( position.y < 0.0 ) {
+
+					offset += - dir;
+
+				} else if ( position.y > 1.0 ) {
+
+					offset += dir;
+
+				}
+
+				// adjust for linewidth
+				offset *= linewidth;
+
+				// adjust for clip-space to screen-space conversion // maybe resolution should be based on viewport ...
+				offset /= resolution.y;
+
+				// select end
+				vec4 clip = ( position.y < 0.5 ) ? clipStart : clipEnd;
+
+				// back to clip space
+				offset *= clip.w;
+
+				clip.xy += offset;
+
+			#endif
+
+			gl_Position = clip;
+
+			vec4 mvPosition = ( position.y < 0.5 ) ? start : end; // this is an approximation
+
+			#include <logdepthbuf_vertex>
+			#include <clipping_planes_vertex>
+			#include <fog_vertex>
+
+		}
+		`,
+
+	fragmentShader:
+	/* glsl */`
+		uniform vec3 diffuse;
+		uniform float opacity;
+		uniform float linewidth;
+
+		#ifdef USE_DASH
+
+			uniform float dashOffset;
+			uniform float dashSize;
+			uniform float gapSize;
+
+		#endif
+
+		varying float vLineDistance;
+
+		#ifdef WORLD_UNITS
+
+			varying vec4 worldPos;
+			varying vec3 worldStart;
+			varying vec3 worldEnd;
+
+			#ifdef USE_DASH
+
+				varying vec2 vUv;
+
+			#endif
+
+		#else
+
+			varying vec2 vUv;
+
+		#endif
+
+		#include <common>
+		#include <color_pars_fragment>
+		#include <fog_pars_fragment>
+		#include <logdepthbuf_pars_fragment>
+		#include <clipping_planes_pars_fragment>
+
+		vec2 closestLineToLine(vec3 p1, vec3 p2, vec3 p3, vec3 p4) {
+
+			float mua;
+			float mub;
+
+			vec3 p13 = p1 - p3;
+			vec3 p43 = p4 - p3;
+
+			vec3 p21 = p2 - p1;
+
+			float d1343 = dot( p13, p43 );
+			float d4321 = dot( p43, p21 );
+			float d1321 = dot( p13, p21 );
+			float d4343 = dot( p43, p43 );
+			float d2121 = dot( p21, p21 );
+
+			float denom = d2121 * d4343 - d4321 * d4321;
+
+			float numer = d1343 * d4321 - d1321 * d4343;
+
+			mua = numer / denom;
+			mua = clamp( mua, 0.0, 1.0 );
+			mub = ( d1343 + d4321 * ( mua ) ) / d4343;
+			mub = clamp( mub, 0.0, 1.0 );
+
+			return vec2( mua, mub );
+
+		}
+
+		void main() {
+
+			float alpha = opacity;
+			vec4 diffuseColor = vec4( diffuse, alpha );
+
+			#include <clipping_planes_fragment>
+
+			#ifdef USE_DASH
+
+				if ( vUv.y < - 1.0 || vUv.y > 1.0 ) discard; // discard endcaps
+
+				if ( mod( vLineDistance + dashOffset, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
+
+			#endif
+
+			#ifdef WORLD_UNITS
+
+				// Find the closest points on the view ray and the line segment
+				vec3 rayEnd = normalize( worldPos.xyz ) * 1e5;
+				vec3 lineDir = worldEnd - worldStart;
+				vec2 params = closestLineToLine( worldStart, worldEnd, vec3( 0.0, 0.0, 0.0 ), rayEnd );
+
+				vec3 p1 = worldStart + lineDir * params.x;
+				vec3 p2 = rayEnd * params.y;
+				vec3 delta = p1 - p2;
+				float len = length( delta );
+				float norm = len / linewidth;
+
+				#ifndef USE_DASH
+
+					#ifdef USE_ALPHA_TO_COVERAGE
+
+						float dnorm = fwidth( norm );
+						alpha = 1.0 - smoothstep( 0.5 - dnorm, 0.5 + dnorm, norm );
+
+					#else
+
+						if ( norm > 0.5 ) {
+
+							discard;
+
+						}
+
+					#endif
+
+				#endif
+
+			#else
+
+				#ifdef USE_ALPHA_TO_COVERAGE
+
+					// artifacts appear on some hardware if a derivative is taken within a conditional
+					float a = vUv.x;
+					float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
+					float len2 = a * a + b * b;
+					float dlen = fwidth( len2 );
+
+					if ( abs( vUv.y ) > 1.0 ) {
+
+						alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
+
+					}
+
+				#else
+
+					if ( abs( vUv.y ) > 1.0 ) {
+
+						float a = vUv.x;
+						float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
+						float len2 = a * a + b * b;
+
+						if ( len2 > 1.0 ) discard;
+
+					}
+
+				#endif
+
+			#endif
+
+			#include <logdepthbuf_fragment>
+			#include <color_fragment>
+
+			gl_FragColor = vec4( diffuseColor.rgb, alpha );
+
+			#include <tonemapping_fragment>
+			#include <colorspace_fragment>
+			#include <fog_fragment>
+			#include <premultiplied_alpha_fragment>
+
+		}
+		`
+};
+
+/**
+ * A material for drawing wireframe-style geometries.
+ *
+ * Unlike {@link LineBasicMaterial}, it supports arbitrary line widths and allows using world units
+ * instead of screen space units. This material is used with {@link LineSegments2} and {@link Line2}.
+ *
+ * This module can only be used with {@link WebGLRenderer}. When using {@link WebGPURenderer},
+ * use {@link Line2NodeMaterial}.
+ *
+ * @augments ShaderMaterial
+ * @three_import import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
+ */
+class LineMaterial extends ShaderMaterial {
+
+	/**
+	 * Constructs a new line segments geometry.
+	 *
+	 * @param {Object} [parameters] - An object with one or more properties
+	 * defining the material's appearance. Any property of the material
+	 * (including any property from inherited materials) can be passed
+	 * in here. Color values can be passed any type of value accepted
+	 * by {@link Color#set}.
+	 */
+	constructor( parameters ) {
+
+		super( {
+
+			type: 'LineMaterial',
+			uniforms: UniformsUtils.clone( ShaderLib[ 'line' ].uniforms ),
+
+			vertexShader: ShaderLib[ 'line' ].vertexShader,
+			fragmentShader: ShaderLib[ 'line' ].fragmentShader,
+
+			clipping: true // required for clipping support
+
+		} );
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isLineMaterial = true;
+
+		this.setValues( parameters );
+
+	}
+
+	/**
+	 * The material's color.
+	 *
+	 * @type {Color}
+	 * @default (1,1,1)
+	 */
+	get color() {
+
+		return this.uniforms.diffuse.value;
+
+	}
+
+	set color( value ) {
+
+		this.uniforms.diffuse.value = value;
+
+	}
+
+	/**
+	 * Whether the material's sizes (width, dash gaps) are in world units.
+	 *
+	 * @type {boolean}
+	 * @default false
+	 */
+	get worldUnits() {
+
+		return 'WORLD_UNITS' in this.defines;
+
+	}
+
+	set worldUnits( value ) {
+
+		if ( ( value === true ) !== this.worldUnits ) {
+
+			this.needsUpdate = true;
+
+		}
+
+		if ( value === true ) {
+
+			this.defines.WORLD_UNITS = '';
+
+		} else {
+
+			delete this.defines.WORLD_UNITS;
+
+		}
+
+	}
+
+	/**
+	 * Controls line thickness in CSS pixel units when `worldUnits` is `false` (default),
+	 * or in world units when `worldUnits` is `true`.
+	 *
+	 * @type {number}
+	 * @default 1
+	 */
+	get linewidth() {
+
+		return this.uniforms.linewidth.value;
+
+	}
+
+	set linewidth( value ) {
+
+		if ( ! this.uniforms.linewidth ) return;
+		this.uniforms.linewidth.value = value;
+
+	}
+
+	/**
+	 * Whether the line is dashed, or solid.
+	 *
+	 * @type {boolean}
+	 * @default false
+	 */
+	get dashed() {
+
+		return 'USE_DASH' in this.defines;
+
+	}
+
+	set dashed( value ) {
+
+		if ( ( value === true ) !== this.dashed ) {
+
+			this.needsUpdate = true;
+
+		}
+
+		if ( value === true ) {
+
+			this.defines.USE_DASH = '';
+
+		} else {
+
+			delete this.defines.USE_DASH;
+
+		}
+
+	}
+
+	/**
+	 * The scale of the dashes and gaps.
+	 *
+	 * @type {number}
+	 * @default 1
+	 */
+	get dashScale() {
+
+		return this.uniforms.dashScale.value;
+
+	}
+
+	set dashScale( value ) {
+
+		this.uniforms.dashScale.value = value;
+
+	}
+
+	/**
+	 * The size of the dash.
+	 *
+	 * @type {number}
+	 * @default 1
+	 */
+	get dashSize() {
+
+		return this.uniforms.dashSize.value;
+
+	}
+
+	set dashSize( value ) {
+
+		this.uniforms.dashSize.value = value;
+
+	}
+
+	/**
+	 * Where in the dash cycle the dash starts.
+	 *
+	 * @type {number}
+	 * @default 0
+	 */
+	get dashOffset() {
+
+		return this.uniforms.dashOffset.value;
+
+	}
+
+	set dashOffset( value ) {
+
+		this.uniforms.dashOffset.value = value;
+
+	}
+
+	/**
+	 * The size of the gap.
+	 *
+	 * @type {number}
+	 * @default 0
+	 */
+	get gapSize() {
+
+		return this.uniforms.gapSize.value;
+
+	}
+
+	set gapSize( value ) {
+
+		this.uniforms.gapSize.value = value;
+
+	}
+
+	/**
+	 * The opacity.
+	 *
+	 * @type {number}
+	 * @default 1
+	 */
+	get opacity() {
+
+		return this.uniforms.opacity.value;
+
+	}
+
+	set opacity( value ) {
+
+		if ( ! this.uniforms ) return;
+		this.uniforms.opacity.value = value;
+
+	}
+
+	/**
+	 * The size of the viewport, in screen pixels. This must be kept updated to make
+	 * screen-space rendering accurate. The `LineSegments2.onBeforeRender` callback
+	 * performs the update for visible objects.
+	 *
+	 * @type {Vector2}
+	 */
+	get resolution() {
+
+		return this.uniforms.resolution.value;
+
+	}
+
+	set resolution( value ) {
+
+		this.uniforms.resolution.value.copy( value );
+
+	}
+
+	/**
+	 * Whether to use alphaToCoverage or not. When enabled, this can improve the
+	 * anti-aliasing of line edges when using MSAA.
+	 *
+	 * @type {boolean}
+	 */
+	get alphaToCoverage() {
+
+		return 'USE_ALPHA_TO_COVERAGE' in this.defines;
+
+	}
+
+	set alphaToCoverage( value ) {
+
+		if ( ! this.defines ) return;
+
+		if ( ( value === true ) !== this.alphaToCoverage ) {
+
+			this.needsUpdate = true;
+
+		}
+
+		if ( value === true ) {
+
+			this.defines.USE_ALPHA_TO_COVERAGE = '';
+
+		} else {
+
+			delete this.defines.USE_ALPHA_TO_COVERAGE;
+
+		}
+
+	}
+
+}
+
+export { LineMaterial };

--- a/src/swift/public/js/vendor/examples/jsm/lines/LineSegments2.js
+++ b/src/swift/public/js/vendor/examples/jsm/lines/LineSegments2.js
@@ -1,0 +1,434 @@
+import {
+	Box3,
+	InstancedInterleavedBuffer,
+	InterleavedBufferAttribute,
+	Line3,
+	MathUtils,
+	Matrix4,
+	Mesh,
+	Sphere,
+	Vector3,
+	Vector4
+} from 'three';
+import { LineSegmentsGeometry } from './LineSegmentsGeometry.js';
+import { LineMaterial } from './LineMaterial.js';
+
+const _viewport = new Vector4();
+
+const _start = new Vector3();
+const _end = new Vector3();
+
+const _start4 = new Vector4();
+const _end4 = new Vector4();
+
+const _ssOrigin = new Vector4();
+const _ssOrigin3 = new Vector3();
+const _mvMatrix = new Matrix4();
+const _line = new Line3();
+const _closestPoint = new Vector3();
+
+const _box = new Box3();
+const _sphere = new Sphere();
+const _clipToWorldVector = new Vector4();
+
+let _ray, _lineWidth;
+
+// Returns the margin required to expand by in world space given the distance from the camera,
+// line width, resolution, and camera projection
+function getWorldSpaceHalfWidth( camera, distance, resolution ) {
+
+	// transform into clip space, adjust the x and y values by the pixel width offset, then
+	// transform back into world space to get world offset. Note clip space is [-1, 1] so full
+	// width does not need to be halved.
+	_clipToWorldVector.set( 0, 0, - distance, 1.0 ).applyMatrix4( camera.projectionMatrix );
+	_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+	_clipToWorldVector.x = _lineWidth / resolution.width;
+	_clipToWorldVector.y = _lineWidth / resolution.height;
+	_clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
+	_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+
+	return Math.abs( Math.max( _clipToWorldVector.x, _clipToWorldVector.y ) );
+
+}
+
+function raycastWorldUnits( lineSegments, intersects ) {
+
+	const matrixWorld = lineSegments.matrixWorld;
+	const geometry = lineSegments.geometry;
+	const instanceStart = geometry.attributes.instanceStart;
+	const instanceEnd = geometry.attributes.instanceEnd;
+	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
+
+	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
+
+		_line.start.fromBufferAttribute( instanceStart, i );
+		_line.end.fromBufferAttribute( instanceEnd, i );
+
+		_line.applyMatrix4( matrixWorld );
+
+		const pointOnLine = new Vector3();
+		const point = new Vector3();
+
+		_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
+		const isInside = point.distanceTo( pointOnLine ) < _lineWidth * 0.5;
+
+		if ( isInside ) {
+
+			intersects.push( {
+				point,
+				pointOnLine,
+				distance: _ray.origin.distanceTo( point ),
+				object: lineSegments,
+				face: null,
+				faceIndex: i,
+				uv: null,
+				uv1: null,
+			} );
+
+		}
+
+	}
+
+}
+
+function raycastScreenSpace( lineSegments, camera, intersects ) {
+
+	const projectionMatrix = camera.projectionMatrix;
+	const material = lineSegments.material;
+	const resolution = material.resolution;
+	const matrixWorld = lineSegments.matrixWorld;
+
+	const geometry = lineSegments.geometry;
+	const instanceStart = geometry.attributes.instanceStart;
+	const instanceEnd = geometry.attributes.instanceEnd;
+	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
+
+	const near = - camera.near;
+
+	//
+
+	// pick a point 1 unit out along the ray to avoid the ray origin
+	// sitting at the camera origin which will cause "w" to be 0 when
+	// applying the projection matrix.
+	_ray.at( 1, _ssOrigin );
+
+	// ndc space [ - 1.0, 1.0 ]
+	_ssOrigin.w = 1;
+	_ssOrigin.applyMatrix4( camera.matrixWorldInverse );
+	_ssOrigin.applyMatrix4( projectionMatrix );
+	_ssOrigin.multiplyScalar( 1 / _ssOrigin.w );
+
+	// screen space
+	_ssOrigin.x *= resolution.x / 2;
+	_ssOrigin.y *= resolution.y / 2;
+	_ssOrigin.z = 0;
+
+	_ssOrigin3.copy( _ssOrigin );
+
+	_mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
+
+	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
+
+		_start4.fromBufferAttribute( instanceStart, i );
+		_end4.fromBufferAttribute( instanceEnd, i );
+
+		_start4.w = 1;
+		_end4.w = 1;
+
+		// camera space
+		_start4.applyMatrix4( _mvMatrix );
+		_end4.applyMatrix4( _mvMatrix );
+
+		// skip the segment if it's entirely behind the camera
+		const isBehindCameraNear = _start4.z > near && _end4.z > near;
+		if ( isBehindCameraNear ) {
+
+			continue;
+
+		}
+
+		// trim the segment if it extends behind camera near
+		if ( _start4.z > near ) {
+
+			const deltaDist = _start4.z - _end4.z;
+			const t = ( _start4.z - near ) / deltaDist;
+			_start4.lerp( _end4, t );
+
+		} else if ( _end4.z > near ) {
+
+			const deltaDist = _end4.z - _start4.z;
+			const t = ( _end4.z - near ) / deltaDist;
+			_end4.lerp( _start4, t );
+
+		}
+
+		// clip space
+		_start4.applyMatrix4( projectionMatrix );
+		_end4.applyMatrix4( projectionMatrix );
+
+		// ndc space [ - 1.0, 1.0 ]
+		_start4.multiplyScalar( 1 / _start4.w );
+		_end4.multiplyScalar( 1 / _end4.w );
+
+		// screen space
+		_start4.x *= resolution.x / 2;
+		_start4.y *= resolution.y / 2;
+
+		_end4.x *= resolution.x / 2;
+		_end4.y *= resolution.y / 2;
+
+		// create 2d segment
+		_line.start.copy( _start4 );
+		_line.start.z = 0;
+
+		_line.end.copy( _end4 );
+		_line.end.z = 0;
+
+		// get closest point on ray to segment
+		const param = _line.closestPointToPointParameter( _ssOrigin3, true );
+		_line.at( param, _closestPoint );
+
+		// check if the intersection point is within clip space
+		const zPos = MathUtils.lerp( _start4.z, _end4.z, param );
+		const isInClipSpace = zPos >= - 1 && zPos <= 1;
+
+		const isInside = _ssOrigin3.distanceTo( _closestPoint ) < _lineWidth * 0.5;
+
+		if ( isInClipSpace && isInside ) {
+
+			_line.start.fromBufferAttribute( instanceStart, i );
+			_line.end.fromBufferAttribute( instanceEnd, i );
+
+			_line.start.applyMatrix4( matrixWorld );
+			_line.end.applyMatrix4( matrixWorld );
+
+			const pointOnLine = new Vector3();
+			const point = new Vector3();
+
+			_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
+
+			intersects.push( {
+				point: point,
+				pointOnLine: pointOnLine,
+				distance: _ray.origin.distanceTo( point ),
+				object: lineSegments,
+				face: null,
+				faceIndex: i,
+				uv: null,
+				uv1: null,
+			} );
+
+		}
+
+	}
+
+}
+
+/**
+ * A series of lines drawn between pairs of vertices.
+ *
+ * This adds functionality beyond {@link LineSegments}, like arbitrary line width and changing width
+ * to be in world units. {@link Line2} extends this object, forming a polyline instead of individual
+ * segments.
+ *
+ * This module can only be used with {@link WebGLRenderer}. When using {@link WebGPURenderer},
+ * import the class from `lines/webgpu/LineSegments2.js`.
+ *
+ *  ```js
+ * const geometry = new LineSegmentsGeometry();
+ * geometry.setPositions( positions );
+ * geometry.setColors( colors );
+ *
+ * const material = new LineMaterial( { linewidth: 5, vertexColors: true } };
+ *
+ * const lineSegments = new LineSegments2( geometry, material );
+ * scene.add( lineSegments );
+ * ```
+ *
+ * @augments Mesh
+ * @three_import import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
+ */
+class LineSegments2 extends Mesh {
+
+	/**
+	 * Constructs a new wide line.
+	 *
+	 * @param {LineSegmentsGeometry} [geometry] - The line geometry.
+	 * @param {LineMaterial} [material] - The line material.
+	 */
+	constructor( geometry = new LineSegmentsGeometry(), material = new LineMaterial( { color: Math.random() * 0xffffff } ) ) {
+
+		super( geometry, material );
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isLineSegments2 = true;
+
+		this.type = 'LineSegments2';
+
+	}
+
+	/**
+	 * Computes an array of distance values which are necessary for rendering dashed lines.
+	 * For each vertex in the geometry, the method calculates the cumulative length from the
+	 * current point to the very beginning of the line.
+	 *
+	 * @return {LineSegments2} A reference to this instance.
+	 */
+	computeLineDistances() {
+
+		// for backwards-compatibility, but could be a method of LineSegmentsGeometry...
+
+		const geometry = this.geometry;
+
+		const instanceStart = geometry.attributes.instanceStart;
+		const instanceEnd = geometry.attributes.instanceEnd;
+		const lineDistances = new Float32Array( 2 * instanceStart.count );
+
+		for ( let i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
+
+			_start.fromBufferAttribute( instanceStart, i );
+			_end.fromBufferAttribute( instanceEnd, i );
+
+			lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
+			lineDistances[ j + 1 ] = lineDistances[ j ] + _start.distanceTo( _end );
+
+		}
+
+		const instanceDistanceBuffer = new InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
+
+		geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
+		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+
+		return this;
+
+	}
+
+	/**
+	 * Computes intersection points between a casted ray and this instance.
+	 *
+	 * @param {Raycaster} raycaster - The raycaster.
+	 * @param {Array<Object>} intersects - The target array that holds the intersection points.
+	 */
+	raycast( raycaster, intersects ) {
+
+		const worldUnits = this.material.worldUnits;
+		const camera = raycaster.camera;
+
+		if ( camera === null && ! worldUnits ) {
+
+			console.error( 'LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2 while worldUnits is set to false.' );
+
+		}
+
+		// early out if no resolution has been set (line was not rendered yet)
+
+		if ( worldUnits === false && ( this.material.resolution.x === 0 || this.material.resolution.y === 0 ) ) {
+
+			return;
+
+		}
+
+		const threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
+
+		_ray = raycaster.ray;
+
+		const matrixWorld = this.matrixWorld;
+		const geometry = this.geometry;
+		const material = this.material;
+
+		_lineWidth = material.linewidth + threshold;
+
+		// check if we intersect the sphere bounds
+		if ( geometry.boundingSphere === null ) {
+
+			geometry.computeBoundingSphere();
+
+		}
+
+		_sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
+
+		// increase the sphere bounds by the worst case line screen space width
+		let sphereMargin;
+		if ( worldUnits ) {
+
+			sphereMargin = _lineWidth * 0.5;
+
+		} else {
+
+			const distanceToSphere = Math.max( camera.near, _sphere.distanceToPoint( _ray.origin ) );
+			sphereMargin = getWorldSpaceHalfWidth( camera, distanceToSphere, material.resolution );
+
+		}
+
+		_sphere.radius += sphereMargin;
+
+		if ( _ray.intersectsSphere( _sphere ) === false ) {
+
+			return;
+
+		}
+
+		// check if we intersect the box bounds
+		if ( geometry.boundingBox === null ) {
+
+			geometry.computeBoundingBox();
+
+		}
+
+		_box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
+
+		// increase the box bounds by the worst case line width
+		let boxMargin;
+		if ( worldUnits ) {
+
+			boxMargin = _lineWidth * 0.5;
+
+		} else {
+
+			const distanceToBox = Math.max( camera.near, _box.distanceToPoint( _ray.origin ) );
+			boxMargin = getWorldSpaceHalfWidth( camera, distanceToBox, material.resolution );
+
+		}
+
+		_box.expandByScalar( boxMargin );
+
+		if ( _ray.intersectsBox( _box ) === false ) {
+
+			return;
+
+		}
+
+		if ( worldUnits ) {
+
+			raycastWorldUnits( this, intersects );
+
+		} else {
+
+			raycastScreenSpace( this, camera, intersects );
+
+		}
+
+	}
+
+	onBeforeRender( renderer ) {
+
+		const uniforms = this.material.uniforms;
+
+		if ( uniforms && uniforms.resolution ) {
+
+			renderer.getViewport( _viewport );
+			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
+
+		}
+
+	}
+
+}
+
+export { LineSegments2 };

--- a/src/swift/public/js/vendor/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/src/swift/public/js/vendor/examples/jsm/lines/LineSegmentsGeometry.js
@@ -1,0 +1,298 @@
+import {
+	Box3,
+	Float32BufferAttribute,
+	InstancedBufferGeometry,
+	InstancedInterleavedBuffer,
+	InterleavedBufferAttribute,
+	Sphere,
+	Vector3,
+	WireframeGeometry
+} from 'three';
+
+const _box = new Box3();
+const _vector = new Vector3();
+
+/**
+ * A series of vertex pairs, forming line segments.
+ *
+ * This is used in {@link LineSegments2} to describe the shape.
+ *
+ * @augments InstancedBufferGeometry
+ * @three_import import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
+ */
+class LineSegmentsGeometry extends InstancedBufferGeometry {
+
+	/**
+	 * Constructs a new line segments geometry.
+	 */
+	constructor() {
+
+		super();
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isLineSegmentsGeometry = true;
+
+		this.type = 'LineSegmentsGeometry';
+
+		const positions = [ - 1, 2, 0, 1, 2, 0, - 1, 1, 0, 1, 1, 0, - 1, 0, 0, 1, 0, 0, - 1, - 1, 0, 1, - 1, 0 ];
+		const uvs = [ - 1, 2, 1, 2, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 2, 1, - 2 ];
+		const index = [ 0, 2, 1, 2, 3, 1, 2, 4, 3, 4, 5, 3, 4, 6, 5, 6, 7, 5 ];
+
+		this.setIndex( index );
+		this.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+
+	}
+
+	/**
+	 * Applies the given 4x4 transformation matrix to the geometry.
+	 *
+	 * @param {Matrix4} matrix - The matrix to apply.
+	 * @return {LineSegmentsGeometry} A reference to this instance.
+	 */
+	applyMatrix4( matrix ) {
+
+		const start = this.attributes.instanceStart;
+		const end = this.attributes.instanceEnd;
+
+		if ( start !== undefined ) {
+
+			start.applyMatrix4( matrix );
+
+			end.applyMatrix4( matrix );
+
+			start.needsUpdate = true;
+
+		}
+
+		if ( this.boundingBox !== null ) {
+
+			this.computeBoundingBox();
+
+		}
+
+		if ( this.boundingSphere !== null ) {
+
+			this.computeBoundingSphere();
+
+		}
+
+		return this;
+
+	}
+
+	/**
+	 * Sets the given line positions for this geometry. The length must be a multiple of six since
+	 * each line segment is defined by a start end vertex in the pattern `(xyz xyz)`.
+	 *
+	 * @param {Float32Array|Array<number>} array - The position data to set.
+	 * @return {LineSegmentsGeometry} A reference to this geometry.
+	 */
+	setPositions( array ) {
+
+		let lineSegments;
+
+		if ( array instanceof Float32Array ) {
+
+			lineSegments = array;
+
+		} else if ( Array.isArray( array ) ) {
+
+			lineSegments = new Float32Array( array );
+
+		}
+
+		const instanceBuffer = new InstancedInterleavedBuffer( lineSegments, 6, 1 ); // xyz, xyz
+
+		this.setAttribute( 'instanceStart', new InterleavedBufferAttribute( instanceBuffer, 3, 0 ) ); // xyz
+		this.setAttribute( 'instanceEnd', new InterleavedBufferAttribute( instanceBuffer, 3, 3 ) ); // xyz
+
+		this.instanceCount = this.attributes.instanceStart.count;
+
+		//
+
+		this.computeBoundingBox();
+		this.computeBoundingSphere();
+
+		return this;
+
+	}
+
+	/**
+	 * Sets the given line colors for this geometry. The length must be a multiple of six since
+	 * each line segment is defined by a start end color in the pattern `(rgb rgb)`.
+	 *
+	 * @param {Float32Array|Array<number>} array - The position data to set.
+	 * @return {LineSegmentsGeometry} A reference to this geometry.
+	 */
+	setColors( array ) {
+
+		let colors;
+
+		if ( array instanceof Float32Array ) {
+
+			colors = array;
+
+		} else if ( Array.isArray( array ) ) {
+
+			colors = new Float32Array( array );
+
+		}
+
+		const instanceColorBuffer = new InstancedInterleavedBuffer( colors, 6, 1 ); // rgb, rgb
+
+		this.setAttribute( 'instanceColorStart', new InterleavedBufferAttribute( instanceColorBuffer, 3, 0 ) ); // rgb
+		this.setAttribute( 'instanceColorEnd', new InterleavedBufferAttribute( instanceColorBuffer, 3, 3 ) ); // rgb
+
+		return this;
+
+	}
+
+	/**
+	 * Setups this line segments geometry from the given wireframe geometry.
+	 *
+	 * @param {WireframeGeometry} geometry - The geometry that should be used as a data source for this geometry.
+	 * @return {LineSegmentsGeometry} A reference to this geometry.
+	 */
+	fromWireframeGeometry( geometry ) {
+
+		this.setPositions( geometry.attributes.position.array );
+
+		return this;
+
+	}
+
+	/**
+	 * Setups this line segments geometry from the given edges geometry.
+	 *
+	 * @param {EdgesGeometry} geometry - The geometry that should be used as a data source for this geometry.
+	 * @return {LineSegmentsGeometry} A reference to this geometry.
+	 */
+	fromEdgesGeometry( geometry ) {
+
+		this.setPositions( geometry.attributes.position.array );
+
+		return this;
+
+	}
+
+	/**
+	 * Setups this line segments geometry from the given mesh.
+	 *
+	 * @param {Mesh} mesh - The mesh geometry that should be used as a data source for this geometry.
+	 * @return {LineSegmentsGeometry} A reference to this geometry.
+	 */
+	fromMesh( mesh ) {
+
+		this.fromWireframeGeometry( new WireframeGeometry( mesh.geometry ) );
+
+		// set colors, maybe
+
+		return this;
+
+	}
+
+	/**
+	 * Setups this line segments geometry from the given line segments.
+	 *
+	 * @param {LineSegments} lineSegments - The line segments that should be used as a data source for this geometry.
+	 * Assumes the source geometry is not using indices.
+	 * @return {LineSegmentsGeometry} A reference to this geometry.
+	 */
+	fromLineSegments( lineSegments ) {
+
+		const geometry = lineSegments.geometry;
+
+		this.setPositions( geometry.attributes.position.array ); // assumes non-indexed
+
+		// set colors, maybe
+
+		return this;
+
+	}
+
+	computeBoundingBox() {
+
+		if ( this.boundingBox === null ) {
+
+			this.boundingBox = new Box3();
+
+		}
+
+		const start = this.attributes.instanceStart;
+		const end = this.attributes.instanceEnd;
+
+		if ( start !== undefined && end !== undefined ) {
+
+			this.boundingBox.setFromBufferAttribute( start );
+
+			_box.setFromBufferAttribute( end );
+
+			this.boundingBox.union( _box );
+
+		}
+
+	}
+
+	computeBoundingSphere() {
+
+		if ( this.boundingSphere === null ) {
+
+			this.boundingSphere = new Sphere();
+
+		}
+
+		if ( this.boundingBox === null ) {
+
+			this.computeBoundingBox();
+
+		}
+
+		const start = this.attributes.instanceStart;
+		const end = this.attributes.instanceEnd;
+
+		if ( start !== undefined && end !== undefined ) {
+
+			const center = this.boundingSphere.center;
+
+			this.boundingBox.getCenter( center );
+
+			let maxRadiusSq = 0;
+
+			for ( let i = 0, il = start.count; i < il; i ++ ) {
+
+				_vector.fromBufferAttribute( start, i );
+				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector ) );
+
+				_vector.fromBufferAttribute( end, i );
+				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector ) );
+
+			}
+
+			this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
+
+			if ( isNaN( this.boundingSphere.radius ) ) {
+
+				console.error( 'THREE.LineSegmentsGeometry.computeBoundingSphere(): Computed radius is NaN. The instanced position data is likely to have NaN values.', this );
+
+			}
+
+		}
+
+	}
+
+	toJSON() {
+
+		// todo
+
+	}
+
+}
+
+export { LineSegmentsGeometry };

--- a/src/swift/public/scripts/build-vendor.cjs
+++ b/src/swift/public/scripts/build-vendor.cjs
@@ -37,6 +37,9 @@ const JSM_DEST = `${VENDOR}/examples/jsm`;
 
 const ENTRY_POINTS = [
   "controls/OrbitControls.js",
+  "lines/Line2.js",
+  "lines/LineGeometry.js",
+  "lines/LineMaterial.js",
   "loaders/ColladaLoader.js",
   "loaders/GLTFLoader.js",
   "loaders/MTLLoader.js",

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -50,6 +50,43 @@ now returns in ~8s (vs. hanging past 2 minutes before either fix), and
 the process now exits cleanly afterward. New test:
 `test_swift_socket_notices_disconnect_even_while_idle`.
 
+## `spatialgeometry.Axes`/`Arrow` weren't rendered at all, misleading error -- fixed 2026-08-02
+
+Found via `spatialgeometry/examples/displaying_axes.py`: `env.add(gm.Axes(...))`
+raised `RuntimeError: Swift failed to load one or more assets for object 0
+-- check the browser's JavaScript console for details (common causes: a
+bad mesh file path, or an unsupported file format)` -- actively misleading,
+since the real cause had nothing to do with a mesh at all.
+`shapes.js`'s `load()` only ever recognised `mesh`/`cuboid`/`box`/`sphere`/
+`cylinder` -- `Axes` and `Arrow` (both genuine, already-shipped
+spatialgeometry shape types, `stype="axes"`/`"arrow"`) fell straight into
+the "unsupported shape type" branch, indistinguishable on the Python side
+from a genuine mesh load failure since both just produced a bare `-1`
+status with the real reason only ever logged to the browser's own JS
+console, never sent back over the wire.
+
+**Fixed:**
+- Protocol: `shape_mounted` now replies `[code, detail]` instead of a bare
+  int -- `-1` unsupported shape type, `-2` asset/mesh load failed (was one
+  undifferentiated `-1` for both), `detail` being the browser's own reason
+  string. `Swift._wait_mounted()`'s exception now says exactly what went
+  wrong (e.g. `unsupported shape type 'axes'`) instead of guessing at
+  "common causes."
+- Rendering: `shapes.js` gained `loadAxes()`/`loadArrow()`/`makeArrow()`.
+  `Axes` renders as `THREE.AxesHelper` by default, or three colored
+  `Arrow`s (R/G/B) when `arrows=True`. `Arrow`'s shaft is a real
+  `CylinderGeometry` when `radius > 0`, otherwise a `Line2`/`LineMaterial`
+  line honoring `linewidth` (previously any line-shaped shaft had no width
+  control at all -- three.js's plain `THREE.Line`/`LineBasicMaterial` is
+  capped at ~1px on virtually all platforms, a long-standing WebGL/ANGLE
+  limitation, not something fixable by just setting a property).
+  `Line2`/`LineGeometry`/`LineMaterial` newly vendored (`build-vendor.cjs`).
+- `spatialgeometry.Axes` gained `arrows`/`radius`/`linewidth` params (the
+  latter two passed straight through to each constituent `Arrow` when
+  `arrows=True`); `Arrow` gained `linewidth` (only applies when
+  `radius == 0` -- the two are mutually exclusive, `radius > 0` always
+  wins, made explicit in both classes' docstrings).
+
 ## `shapes.js` mesh loading: `.obj`/`.gltf`/`.glb`/`.ply` skip the local-file proxy `.dae`/`.stl` use
 
 Found 2026-07-31, as a byproduct of checking whether `sg.Mesh()` can load

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -70,7 +70,7 @@ def make_env():
 
 def test_add_shape_sends_a_one_element_part_list():
     env = make_env()
-    browser = FakeBrowser(env, responses=["0", "1"])
+    browser = FakeBrowser(env, responses=["0", json.dumps([1, None])])
 
     box = sg.Cuboid([0.1, 0.1, 0.1], pose=sm.SE3(), color=[1, 0, 0, 1])
     box_id = env.add(box)
@@ -95,13 +95,29 @@ def test_add_shape_raises_when_browser_reports_a_load_error():
     # Regression test for bugs.md Bug 2: adding a mesh whose file the
     # browser can't load used to poll "shape_mounted" forever since a
     # failed load never became mounted=1 -- see shapes.js's onError
-    # handlers, which now report failure as -1 instead of leaving the
-    # SwiftObject stuck at loaded < len(parts) forever.
+    # handlers, which now report failure as [-2, reason] instead of
+    # leaving the SwiftObject stuck at loaded < len(parts) forever.
     env = make_env()
-    browser = FakeBrowser(env, responses=["0", "-1"])
+    browser = FakeBrowser(env, responses=["0", json.dumps([-2, "failed to load STL file"])])
 
     box = sg.Cuboid([0.1, 0.1, 0.1], pose=sm.SE3())
-    with pytest.raises(RuntimeError, match="failed to load"):
+    with pytest.raises(RuntimeError, match="failed to load STL file"):
+        env.add(box)
+    browser.stop()
+
+
+def test_add_shape_raises_with_the_specific_reason_for_an_unsupported_shape_type():
+    # Regression test: -1 (unsupported shape type, e.g. spatialgeometry.Axes/
+    # Arrow before shapes.js grew support for them) used to be
+    # indistinguishable from -2 (a genuine mesh/asset load failure) -- both
+    # just meant "check the browser console." Now the browser's own reason
+    # travels back over the wire, so the exception is specific without
+    # needing the console at all.
+    env = make_env()
+    browser = FakeBrowser(env, responses=["0", json.dumps([-1, "unsupported shape type 'made_up_type'"])])
+
+    box = sg.Cuboid([0.1, 0.1, 0.1], pose=sm.SE3())
+    with pytest.raises(RuntimeError, match="unsupported shape type 'made_up_type'"):
         env.add(box)
     browser.stop()
 
@@ -125,7 +141,7 @@ def test_add_robot_sends_flat_list_of_all_link_parts():
     for gripper in panda.grippers:
         n_parts += sum(len(link.geometry) for link in gripper.links)
 
-    browser = FakeBrowser(env, responses=["0", "1"])
+    browser = FakeBrowser(env, responses=["0", json.dumps([1, None])])
     robot_id = env.add(panda)
 
     codes = [c for c, _ in browser.received]
@@ -143,7 +159,7 @@ def test_add_robot_sends_flat_list_of_all_link_parts():
 
 def test_draw_all_batches_poses_by_object_index_and_returns_element_events():
     env = make_env()
-    browser = FakeBrowser(env, responses=["0", "1"])
+    browser = FakeBrowser(env, responses=["0", json.dumps([1, None])])
 
     box = sg.Cuboid([0.1, 0.1, 0.1], pose=sm.SE3())
     env.add(box)
@@ -160,7 +176,7 @@ def test_draw_all_batches_poses_by_object_index_and_returns_element_events():
 
 def test_remove_sends_the_raw_object_index():
     env = make_env()
-    browser = FakeBrowser(env, responses=["0", "1", "0"])
+    browser = FakeBrowser(env, responses=["0", json.dumps([1, None]), "0"])
 
     box = sg.Cuboid([0.1, 0.1, 0.1], pose=sm.SE3())
     box_id = env.add(box)


### PR DESCRIPTION
## Summary

`spatialgeometry.Axes`/`Arrow` are genuine, already-shipped shape types
(`stype="axes"`/`"arrow"`), but `shapes.js`'s `load()` never recognised
either -- both fell into the "unsupported shape type" branch, which
produced the same misleading generic error as an actual mesh-load failure
("check the browser's JavaScript console... common causes: a bad mesh file
path, or an unsupported file format"), with the real reason only ever
logged client-side, never sent back over the wire.

## Changes

- **Protocol**: `shape_mounted` now replies `[code, detail]` instead of a
  bare int -- `-1` unsupported shape type, `-2` asset/mesh load failed
  (previously one undifferentiated `-1` for both). `Swift._wait_mounted()`'s
  exception now says exactly what went wrong (e.g.
  `unsupported shape type 'axes'`) instead of guessing at "common causes."
- **Rendering** (`shapes.js`): `loadAxes()`/`loadArrow()`/`makeArrow()`.
  `Axes` renders as `THREE.AxesHelper` by default, or three colored
  `Arrow`s (R/G/B) when `arrows=True`. `Arrow`'s shaft is a real
  `CylinderGeometry` when `radius > 0`, otherwise a `Line2`/`LineMaterial`
  line honoring `linewidth` -- plain `THREE.Line`/`LineBasicMaterial` is
  capped at ~1px on virtually all platforms (a long-standing WebGL/ANGLE
  limitation), so this is the first shape in the codebase with real
  pixel-width line control. `Line2`/`LineGeometry`/`LineMaterial` newly
  vendored via `build-vendor.cjs`.
- **spatialgeometry** (companion PR, `feat/axes-arrow-linewidth`):
  `Axes` gained `arrows`/`radius`/`linewidth` params (the latter two
  passed straight through to each constituent `Arrow` when `arrows=True`);
  `Arrow` gained `linewidth` (mutually exclusive with `radius` -- `radius
  > 0` always wins, made explicit in both classes' docstrings).

## Test plan

- [x] `pytest tests/` -- 68 passed, including new tests distinguishing
      `-1` (unsupported shape type) from `-2` (load failure).
- [x] Manually verified in a real browser: default `Axes`, `arrows=True`
      `Axes`, and `Arrow` with both `radius>0` (cylinder) and `radius=0`
      (`Line2`) shafts.