### PR TITLE
fix: default camera position put +x axis on screen-left, not right

### DIFF
--- a/src/swift/public/js/scene.js
+++ b/src/swift/public/js/scene.js
@@ -38,7 +38,11 @@ export function createScene() {
     0.01,
     10
   );
-  camera.position.set(0.2, 1.2, 0.7);
+  // Negative y puts the camera on the side that makes the world +x axis
+  // (AxesHelper's red line) read as screen-right, matching the usual
+  // convention -- with DEFAULT_UP = +z, a camera at +y looking back
+  // toward the origin has its own right vector pointing -x.
+  camera.position.set(0.2, -1.2, 0.7);
 
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x787878);


### PR DESCRIPTION
## Summary

`camera.position.set(0.2, 1.2, 0.7)` -- with `DEFAULT_UP = (0, 0, 1)`, a
camera positioned on the +y side of the origin and looking back toward
it has its own *right* vector pointing -x (worked out via
`cross(up, eye-target)`). So the `AxesHelper`'s red +x line rendered on
the left of the screen instead of the right, which reads as
unintuitive/backwards for the default view.

## Fix

Negate just the y coordinate (`0.2, -1.2, 0.7`) -- moves the camera to
the other side of the scene, flipping its right vector to +x. Left the
x offset and the `OrbitControls` target (`0, 0, 0.2`) unchanged.

## Test plan

- [x] `pytest tests/` -- 68 passed (unchanged, this is a pure rendering
      default).
- [x] Verified visually via a real screenshot (`env.screenshot()`), not
      just the vector math -- confirmed the red +x line now renders on
      the right.