### PR TITLE
feat: render spatialgeometry.Path -- polyline through waypoints

### DIFF
--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -199,6 +199,51 @@ function loadAxes(part, scene, cb) {
   finish(part, axes, scene, cb);
 }
 
+/**
+ * spatialgeometry.Path: a polyline through a sequence of waypoints --
+ * straight segments joining consecutive points, not a smoothed curve.
+ * radius == 0 renders as a single screen-space-width Line2 (mirrors
+ * Arrow's line-mode shaft, connecting every point in sequence); radius > 0
+ * renders as a real tube built from a CurvePath of straight LineCurve3
+ * segments, so bends stay sharp corners rather than getting smoothed the
+ * way a spline through the same points would -- same logical path either
+ * way, only the rendering mode differs (matches Arrow's own radius vs.
+ * linewidth invariant).
+ *
+ * Unlike Arrow/Axes, a Path is always a single object (one Line2, or one
+ * Mesh) in either mode -- no Group/userData.disposables wrapper needed,
+ * disposeMesh()'s plain disposeChild() fallback (same path loadPrimitive()
+ * uses) is enough.
+ */
+function makePath(points, radius, linewidth, color) {
+  const vectors = points.map((p) => new THREE.Vector3(p[0], p[1], p[2]));
+
+  if (radius > 0) {
+    const curvePath = new THREE.CurvePath();
+    for (let i = 0; i < vectors.length - 1; i++) {
+      curvePath.add(new THREE.LineCurve3(vectors[i], vectors[i + 1]));
+    }
+    const tubularSegments = Math.max(1, vectors.length - 1);
+    const geometry = new THREE.TubeGeometry(curvePath, tubularSegments, radius, 16, false);
+    return new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ color, specular: 0x111111, shininess: 200 }));
+  }
+
+  const positions = vectors.flatMap((v) => [v.x, v.y, v.z]);
+  const lineGeometry = new LineGeometry();
+  lineGeometry.setPositions(positions);
+  const material = new LineMaterial({ color, linewidth, worldUnits: false });
+  material.resolution.copy(lineResolution);
+  const line = new Line2(lineGeometry, material);
+  lineMaterials.push(material); // kept in sync on resize -- see scene.js
+  return line;
+}
+
+function loadPath(part, scene, cb) {
+  const path = makePath(part.points, part.radius, part.linewidth, part.color);
+  setPose(path, part.t, part.q);
+  finish(part, path, scene, cb);
+}
+
 function loadMesh(part, scene, cb, errCb) {
   const ext = part.filename.split(".").pop().toLowerCase();
 
@@ -349,6 +394,7 @@ function load(part, scene, cb, errCb) {
   else if (["cuboid", "box", "sphere", "cylinder"].includes(part.stype)) loadPrimitive(part, scene, cb);
   else if (part.stype === "axes") loadAxes(part, scene, cb);
   else if (part.stype === "arrow") loadArrow(part, scene, cb);
+  else if (part.stype === "path") loadPath(part, scene, cb);
   else {
     const reason = `unsupported shape type '${part.stype}'`;
     console.error(reason);

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,6 +15,7 @@ import json
 import threading
 from queue import Queue
 
+import numpy as np
 import pytest
 import roboticstoolbox as rtb
 import spatialgeometry as sg
@@ -88,6 +89,22 @@ def test_add_shape_sends_a_one_element_part_list():
 
     _, mounted_data = browser.received[1]
     assert mounted_data == [box_id, 1]
+    browser.stop()
+
+
+def test_add_path_sends_points_radius_and_linewidth():
+    env = make_env()
+    browser = FakeBrowser(env, responses=["0", json.dumps([1, None])])
+
+    points = np.array([[0.0, 1.0, 2.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    path = sg.Path(points, radius=0.02, linewidth=2.0, color=[1.0, 0.0, 0.0, 1.0])
+    env.add(path)
+
+    _, shape_data = browser.received[0]
+    assert shape_data[0]["stype"] == "path"
+    assert shape_data[0]["points"] == [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]
+    assert shape_data[0]["radius"] == 0.02
+    assert shape_data[0]["linewidth"] == 2.0
     browser.stop()
 
 


### PR DESCRIPTION
## Summary

Closes jhavl/swift#51 ("Drawing lines/trajectories in Swift"), together
with the companion spatialgeometry PR (jhavl/spatialgeometry#13) that
adds the actual `Path` shape class.

## Changes

`shapes.js` gains `makePath()`/`loadPath()`, mirroring `Arrow`'s
radius/linewidth mutual exclusivity:

- `radius == 0`: a single screen-space-width `Line2` through all
  waypoints in sequence -- reuses the `resizeLines()`/`lineMaterials`
  machinery already built for `Arrow`'s line-mode shaft, no new
  vendoring needed.
- `radius > 0`: a real tube via `THREE.TubeGeometry`, fed a
  `THREE.CurvePath` of straight `THREE.LineCurve3` segments -- **not**
  a smoothed spline through the points. This keeps bends as sharp
  corners, so the rendered shape doesn't silently diverge from the
  actual waypoints depending on which mode (`radius` vs `linewidth`)
  happens to be active -- same invariant `Arrow` already has between
  its line and cylinder shaft modes.

Unlike `Arrow`/`Axes`, a `Path` is always a single object (one `Line2`
or one `Mesh`) in either mode -- no `Group`/`userData.disposables`
wrapper needed; the existing `disposeMesh()` fallback (same path
`loadPrimitive()`'s cuboid/sphere/cylinder already use) handles cleanup.

## Test plan

- [x] `pytest tests/` -- 68 passed, including a new
      `test_add_path_sends_points_radius_and_linewidth`.
- [x] `node --test src/swift/public/js/*.test.js` -- unaffected, 2 passed.
- [x] Verified live via two real screenshots (not just reasoning about
      the code): line mode and tube mode, both through the same 4-point
      path with one sharp bend -- tube mode's joint renders cleanly, no
      pinching/twisting artifacts.