### PR TITLE
fix: move directional lights to match camera's new -y position

### DIFF
--- a/src/swift/public/js/scene.js
+++ b/src/swift/public/js/scene.js
@@ -81,8 +81,11 @@ export function createScene() {
   scene.add(ground);
 
   scene.add(new THREE.HemisphereLight(0x666666, 0x222233));
-  addShadowedLight(scene, 1, 1, 1, 0xffffff, 1.35);
-  addShadowedLight(scene, 0.5, 1, -1, 0xffffff, 1);
+  // y negated to match the camera's -y position above -- these lights
+  // need to stay on the camera's side of the scene, else the faces
+  // facing the camera end up in shadow.
+  addShadowedLight(scene, 1, -1, 1, 0xffffff, 1.35);
+  addShadowedLight(scene, 0.5, -1, -1, 0xffffff, 1);
 
   const axesHelper = new THREE.AxesHelper(5);
   scene.add(axesHelper);


### PR DESCRIPTION
## Summary
- #96 moved the default camera to the `-y` side of the scene to fix the `AxesHelper`'s screen-left/right orientation, but left both `addShadowedLight()` calls on the old `+y` side.
- The two directional lights were now on the opposite side from the camera, so the faces facing the camera were lit from behind and rendered dark/in shadow.
- Negates each light's `y` position to match, keeping them on the camera's side of the scene.

## Test plan
- [x] Ran `examples/box.py` and `examples/busy_scene.py`, confirmed the camera-facing faces are lit rather than dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)