### PR TITLE
fix: don't mark opaque shapes as transparent in materialFor()

### DIFF
--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -62,7 +62,13 @@ function materialFor(part) {
     color: part.color,
     specular: 0x111111,
     shininess: 200,
-    transparent: true,
+    // Only join the transparent render queue for genuinely translucent
+    // shapes -- three.js sorts transparent objects per-object (by bounding
+    // sphere distance), not per-pixel, so an opaque shape marked transparent
+    // can win outright against another transparent object it intersects
+    // (e.g. a shape straddling the translucent ground plane) instead of
+    // being correctly depth-tested against it.
+    transparent: part.opacity < 1,
     opacity: part.opacity,
   });
 }


### PR DESCRIPTION
## Summary
- `materialFor()` unconditionally set `transparent: true` on every shape's material, even fully-opaque ones (`opacity: 1.0`).
- This puts opaque shapes in three.js's transparent render queue, which sorts whole objects by bounding-sphere distance rather than per-pixel. A shape intersecting another translucent object (e.g. one straddling the ground plane at a low `ground_opacity`) could win outright at its own screen footprint instead of being correctly depth-tested against it -- producing a hard cutoff instead of a per-pixel blend.
- Now only genuinely translucent shapes (`opacity < 1`) join the transparent queue.

## Test plan
- [x] Reproduced with a cuboid straddling the ground plane (`pose=SE3(0,0,0)`, `ground_opacity=0.1`): before the fix, the buried half rendered as a hard opaque cutoff instead of blending with the translucent ground; after the fix, it blends correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)