### PR TITLE
fix: disable HTTP caching on swift's local dev server responses

### DIFF
--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -295,6 +295,17 @@ class SwiftServer:
                 else:
                     pass
 
+            def end_headers(self):
+                # This server's process (and the port it's bound to) never
+                # outlives one Python session, so there's no real caching
+                # benefit -- only the risk of a browser silently serving a
+                # stale cached JS/mesh file across a dev-session file edit
+                # (hit repeatedly in practice: scene.js and ui.js each
+                # served stale after an on-disk fix, only noticed because
+                # the fix appeared to have no effect).
+                self.send_header("Cache-Control", "no-store")
+                http.server.SimpleHTTPRequestHandler.end_headers(self)
+
             def do_GET(self):
                 if self.path == "/":
                     self.send_response(301)


### PR DESCRIPTION
## Summary
- `SwiftServer`'s HTTP responses only ever sent `Last-Modified`, letting browsers cache heuristically and skip revalidation.
- This server's process (and the port it binds) never outlives one Python session, so there's no real caching benefit -- only the risk of a stale cached JS/mesh file silently surviving a dev-session file edit. Hit repeatedly in practice: `scene.js` and `ui.js` each appeared to have "no effect" after an on-disk fix, purely because the browser was still serving a cached copy from before the edit.
- Adds `Cache-Control: no-store` via a single `end_headers()` override on the request handler, covering the `/` redirect, the index page, static assets, and the `/retrieve/` mesh passthrough uniformly.

## Test plan
- [x] `pytest tests/test_protocol.py` -- 28 passed
- [x] Verified via `curl -sD -` against a live instance: `Cache-Control: no-store` present on all three response paths (redirect, index, static asset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)