### PR TITLE
fix: cylinder primitive rendered along Y instead of Z

### DIFF
--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -109,6 +109,10 @@ function loadPrimitive(part, scene, cb) {
     geometry = new THREE.SphereGeometry(part.radius, 64, 64);
   } else if (part.stype === "cylinder") {
     geometry = new THREE.CylinderGeometry(part.radius, part.radius, part.length, 32);
+    // CylinderGeometry's default axis is Y -- rotate onto Z to match
+    // spatialgeometry's Cylinder ("axis along Z"), same correction the
+    // Arrow shaft cylinder below already applies for its own +Z convention.
+    geometry.rotateX(Math.PI / 2);
   }
   const mesh = new THREE.Mesh(geometry, materialFor(part));
   setPose(mesh, part.t, part.q);


### PR DESCRIPTION
## Summary
- `THREE.CylinderGeometry` defaults to a Y-axis, but spatialgeometry's `Cylinder` docstring specifies "axis along Z", and its collision geometry (coal's `Cylinder`) already follows that convention -- swift's own JS rendering was the only place still assuming Y.
- The `Arrow` shaft cylinder right below this code already applies the same `rotateX(Math.PI / 2)` correction for its own +Z convention; the primitive `Cylinder` just never got it.
- Pure rotation, no translate -- `CylinderGeometry` is centred on its local origin by default, so the fix doesn't change the shape's reference point (confirmed centred both before and after the rotation, and verified visually with a side-on camera view against the `AxesHelper`'s own axis line).

## Test plan
- [x] Rendered a `Cylinder` with a default (identity) pose and confirmed its axis is now vertical (parallel to the world Z axis / `AxesHelper`), not diagonal.
- [x] Verified via a side-on `set_camera_pose()` view that the shape remains centre-referenced (matching every other primitive), not shifted to a base or top reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)