### PR TITLE
fix: mesh loaders (obj/gltf/ply/wrl/pcd) fetched raw filesystem paths

### DIFF
--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -219,7 +219,15 @@ function loadMesh(part, scene, cb, errCb) {
   // and Swift._wait_mounted() in Swift.py); a swallowed error here means
   // that poll spins forever with no way for the caller to find out why.
   const onError = (label) => (error) => {
-    const reason = `failed to load ${label} file '${part.filename}': ${error}`;
+    // FileLoader routes both fetch-level failures (a non-2xx HTTP response,
+    // which it wraps in an HttpError carrying the real Response as
+    // .response) and this loader's own parse() exceptions (thrown on
+    // malformed/unsupported file content) through this same callback --
+    // distinguishing them here is the difference between "wrong path" and
+    // "found it, but couldn't read it" for whoever's debugging this.
+    const reason = error?.response
+      ? `${label} file '${part.filename}' not found: server responded ${error.response.status} ${error.response.statusText} for ${error.response.url}`
+      : `${label} file '${part.filename}' was fetched but could not be parsed -- likely malformed or an unsupported variant of this format: ${error}`;
     console.error(reason, error);
     errCb(-2, reason);
   };
@@ -258,12 +266,12 @@ function loadMesh(part, scene, cb, errCb) {
     );
   } else if (ext === "obj") {
     mtlLoader.load(
-      part.filename.slice(0, part.filename.length - 3) + "mtl",
+      url.slice(0, url.length - 3) + "mtl",
       (materials) => {
         materials.preload();
         objLoader.setMaterials(materials);
         objLoader.load(
-          part.filename,
+          url,
           (object) => {
             object.traverse((child) => {
               if (child.isMesh) {
@@ -278,11 +286,13 @@ function loadMesh(part, scene, cb, errCb) {
           onProgress,
           onError("obj")
         );
-      }
+      },
+      onProgress,
+      onError("MTL")
     );
   } else if (ext === "gltf" || ext === "glb") {
     gltfLoader.load(
-      part.filename,
+      url,
       (gltf) => {
         const mesh = gltf.scene;
         mesh.traverse((child) => {
@@ -300,7 +310,7 @@ function loadMesh(part, scene, cb, errCb) {
     );
   } else if (ext === "ply") {
     plyLoader.load(
-      part.filename,
+      url,
       (geometry) => {
         geometry.computeVertexNormals();
         const mesh = new THREE.Mesh(geometry, materialFor(part));
@@ -315,7 +325,7 @@ function loadMesh(part, scene, cb, errCb) {
     );
   } else if (ext === "wrl") {
     vrmLoader.load(
-      part.filename,
+      url,
       (mesh) => {
         mesh.castShadow = true;
         mesh.receiveShadow = true;
@@ -328,7 +338,7 @@ function loadMesh(part, scene, cb, errCb) {
     );
   } else if (ext === "pcd") {
     pcdLoader.load(
-      part.filename,
+      url,
       (mesh) => {
         mesh.scale.set(part.scale[0], part.scale[1], part.scale[2]);
         setPose(mesh, part.t, part.q);


### PR DESCRIPTION
## Summary
- Mesh filenames arrive as absolute filesystem paths, only servable through `SwiftServer`'s `/retrieve/<path>` passthrough route. `dae` and `stl` already built that URL correctly, but `obj` (both its mesh and its `.mtl` companion), `gltf`/`glb`, `ply`, `wrl`, and `pcd` all passed `part.filename` straight to their loader, which the browser resolved against the HTTP server's own root and always 404'd.
- Also gives `.obj`'s MTL load its own `onProgress`/`onError` -- it previously had neither, so a missing/broken `.mtl` file would silently hang `Swift.py`'s `add_shape()` "shape_mounted" poll forever instead of surfacing a load error.
- Additionally makes the shared `onError()` distinguish an HTTP fetch failure (`FileLoader`'s `HttpError` carries the real `Response` as `.response`) from a same-file parse failure -- previously both looked identical (`"failed to load X: [object Object]"`-style messages), making "wrong path" indistinguishable from "found it, but couldn't parse it as this format".

## Test plan
- [x] Loaded a real `.ply` file via an absolute path -- confirmed it renders (previously 404'd).
- [x] Loaded a nonexistent `.ply` path -- confirmed the new error message clearly states "not found", the HTTP status, and the exact URL that 404'd.
- [x] `node --test src/swift/public/js/*.test.js` -- all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)