### PR TITLE
fix: callback-driven shapes never sent color/scale/opacity updates

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -432,6 +432,7 @@ class Swift:
                     cb = self.shape_callbacks.get(i)
                     if cb is not None:
                         obj.T = cb(t, values)
+                        self._send_shape_update_if_changed(obj)
                     else:
                         self._step_shape(obj, dt)
                 elif isinstance(obj, AssemblyHandle):
@@ -1128,12 +1129,24 @@ class Swift:
         # function of handle.q, rather than reading the scene-graph's
         # mutated/cached world transform. See jhavl/swift#85.
 
-    def _step_shape(self, shape, dt):
-
+    def _send_shape_update_if_changed(self, shape):
+        # A shape's @update-decorated setters (color, opacity, scale, ...)
+        # only flip shape._changed -- this is the one place that turns that
+        # flag into an actual "shape_update" message. Must run for every
+        # shape every step, callback-driven or not (see step()'s caller in
+        # the cb-is-not-None branch) -- it used to only run from within
+        # _step_shape(), which callback-driven shapes never reach, so a
+        # callback shape's color/scale/opacity changes were silently
+        # dropped forever, even though its pose kept updating fine via the
+        # callback's own SE3 return value.
         if shape._changed:
             shape._changed = False
             id = self.swift_objects.index(shape)
             self._send_socket("shape_update", [id, shape.to_dict()])
+
+    def _step_shape(self, shape, dt):
+
+        self._send_shape_update_if_changed(shape)
 
         step_shape(
             dt, shape.v, shape._SceneNode__T, shape._SceneNode__wT, shape._SceneNode__wq


### PR DESCRIPTION
## Summary
- `step()`'s main loop takes a completely different path for a shape with a registered `callback=` (`obj.T = cb(t, values)`) versus one without (`_step_shape(obj, dt)`) -- only the latter ever checked `shape._changed` and sent a `"shape_update"` message.
- A callback shape's pose kept updating fine (the callback's return value drives that directly), but setting `.color`/`.opacity`/`.scale` on it had no visible effect at all, since nothing ever read the `_changed` flag those setters set.
- Extracts the check-and-send into `_send_shape_update_if_changed()`, called from both branches -- callback-driven shapes still skip the velocity-integration `step_shape()` call (the callback already owns their pose), but no longer skip the property-update push.

## Test plan
- [x] Reproduced with a callback-driven `Sphere` whose `.color` was set on a collision condition -- before the fix, only a non-callback `Cuboid` in the same scene changed color; after the fix, both do.
- [x] `pytest tests/` -- 66 passed, 4 skipped (pre-existing skips, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)