### PR TITLE
feat: use a mesh's own vertex colors when no explicit color was given

### DIFF
--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -57,9 +57,16 @@ function setPose(object3d, t, q) {
   object3d.quaternion.set(q[0], q[1], q[2], q[3]);
 }
 
-function materialFor(part) {
+function materialFor(part, geometry) {
+  // Mesh.to_dict() sets use_vertex_colors when no explicit color= was ever
+  // given (see spatialgeometry's Mesh) -- in that case, prefer whatever
+  // per-vertex/per-face colors the loader parsed out of the file itself
+  // (PLY/STL both support this) over the flat default. Primitives (no
+  // geometry passed, or no color attribute present) are unaffected.
+  const useVertexColors = !!(part.use_vertex_colors && geometry?.hasAttribute("color"));
   return new THREE.MeshPhongMaterial({
-    color: part.color,
+    color: useVertexColors ? 0xffffff : part.color,
+    vertexColors: useVertexColors,
     specular: 0x111111,
     shininess: 200,
     transparent: true,
@@ -246,7 +253,7 @@ function loadMesh(part, scene, cb, errCb) {
     stlLoader.load(
       url,
       (geometry) => {
-        const mesh = new THREE.Mesh(geometry, materialFor(part));
+        const mesh = new THREE.Mesh(geometry, materialFor(part, geometry));
         mesh.scale.set(part.scale[0], part.scale[1], part.scale[2]);
         setPose(mesh, part.t, part.q);
         mesh.castShadow = true;
@@ -303,7 +310,7 @@ function loadMesh(part, scene, cb, errCb) {
       part.filename,
       (geometry) => {
         geometry.computeVertexNormals();
-        const mesh = new THREE.Mesh(geometry, materialFor(part));
+        const mesh = new THREE.Mesh(geometry, materialFor(part, geometry));
         mesh.castShadow = true;
         mesh.receiveShadow = true;
         mesh.scale.set(part.scale[0], part.scale[1], part.scale[2]);


### PR DESCRIPTION
## Summary
- `materialFor()` always applied a flat `part.color` override to every mesh, discarding any per-vertex/per-face colors `PLYLoader`/`STLLoader` parsed straight out of the file (both formats support embedding them, and `PLYLoader` already sets a geometry `"color"` attribute when present -- nothing on the rendering side ever looked at it).
- Now checks the new `part.use_vertex_colors` field (set by spatialgeometry's `Mesh.to_dict()` when no `color=` was ever explicitly given) together with `geometry.hasAttribute("color")`, and enables `THREE.MeshPhongMaterial`'s `vertexColors` instead of overriding with the flat default whenever both are true. An explicit `color=` still always wins, at construction or set later, same as before.
- Only `.stl` and `.ply` call `materialFor()` at all -- `.obj`/`.gltf`/`.dae` build their own real materials from the file's own material/texture data already and never touch this path; `.wrl`/`.pcd` don't call `materialFor()` either currently (a separate, pre-existing gap, out of scope here).

## Depends on
- petercorke/spatialgeometry's `feat/mesh-explicit-color-tracking` ([jhavl/spatialgeometry#19](https://github.com/jhavl/spatialgeometry/pull/19)) for the `use_vertex_colors` field this reads. Without it, `part.use_vertex_colors` is simply always `undefined` and this is a no-op -- safe to merge in either order, but needs both to actually change behavior.

## Test plan
- [x] Loaded a real `.ply` file with embedded per-vertex colors (previously rendered as flat grey/near-black) -- confirmed it now renders with its real colors.
- [x] `node --test src/swift/public/js/*.test.js` -- all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)