### PR TITLE
feat: add launch(ground_pattern=, ground_pattern_width=) for a tiled floor

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -239,6 +239,8 @@ class Swift:
         browser: str | None = None,
         axes: bool = True,
         ground_opacity: float = 1.0,
+        ground_pattern: bool | str = False,
+        ground_pattern_width: float = 1.0,
         timeout: float | None = 1,
         browser_timeout: float | None = 5,
         **kwargs,
@@ -307,6 +309,22 @@ class Swift:
         :param ground_opacity: Opacity of the ground plane, from 0
             (invisible) to 1 (opaque), defaults to 1
         :type ground_opacity: float
+        :param ground_pattern: Repeating pattern on the ground plane.
+            ``False`` (default) is a plain flat floor. ``True`` or
+            ``"@tile"`` is a built-in checkerboard; ``"@grid"`` is a
+            built-in grid. Anything else is treated as an absolute path
+            to an image file to tile as a texture -- its tile height
+            follows the image's own aspect ratio (never distorted); see
+            ``ground_pattern_width``. Whenever a pattern is active, the
+            ground plane recentres under the camera every frame (snapped
+            to a whole tile, so the pattern never visibly shifts) so its
+            edge is never reachable regardless of pan/zoom -- skipped
+            entirely for the plain flat floor, which has no visible edge
+            to begin with.
+        :type ground_pattern: bool | str
+        :param ground_pattern_width: x-extent of one tile, in metres.
+            Only meaningful when ``ground_pattern`` is set, defaults to 1.
+        :type ground_pattern_width: float
         :param timeout: how long :meth:`hold` keeps waiting, in seconds,
             after the browser tab disconnects before giving up and
             returning. ``None`` means wait indefinitely (the pre-2.1
@@ -337,6 +355,8 @@ class Swift:
         self.headless = headless
         self.axes = axes
         self.ground_opacity = ground_opacity
+        self.ground_pattern = ground_pattern
+        self.ground_pattern_width = ground_pattern_width
         # Anchors realtime_speed's pacing clock (see step()) -- needed in
         # headless mode too, not just for rendering.
         self.last_time = time.time()
@@ -361,6 +381,13 @@ class Swift:
 
             if self.ground_opacity != 1.0:
                 self._send_socket("ground_opacity", self.ground_opacity, expected=False)
+
+            if self.ground_pattern:
+                self._send_socket(
+                    "ground_pattern",
+                    {"pattern": self.ground_pattern, "width": self.ground_pattern_width},
+                    expected=False,
+                )
 
             self._send_socket("browser_timeout", self._browser_timeout, expected=False)
 

--- a/src/swift/public/js/main.js
+++ b/src/swift/public/js/main.js
@@ -1,11 +1,11 @@
-import { createScene } from "./scene.js";
+import { createScene, setGroundPattern, updateGroundPatternPosition } from "./scene.js";
 import { SwiftObject } from "./shapes.js";
 import { Slider, Button, Label, Select, Checkbox, Radio } from "./ui.js";
 import { WebSocketTransport, portFromLocation } from "./comms.js";
 import { Recorder } from "./recording.js";
 import { FPS, SimTime } from "./hud.js";
 
-const { scene, camera, renderer, controls, axesHelper, groundMaterial } = createScene();
+const { scene, camera, renderer, controls, axesHelper, ground, groundMaterial } = createScene();
 
 const fps = new FPS(document.getElementById("fps"));
 const simTime = new SimTime(document.getElementById("sim-time"));
@@ -164,6 +164,10 @@ transport.onMessage((func, data) => {
       groundMaterial.opacity = data;
       break;
     }
+    case "ground_pattern": {
+      setGroundPattern(ground, groundMaterial, data.pattern, data.width);
+      break;
+    }
     case "camera_pose": {
       camera.position.set(...data.t);
       camera.lookAt(...data.look_at);
@@ -200,6 +204,7 @@ transport.onMessage((func, data) => {
 function animate() {
   if (!connected) return; // freeze on the last frame instead of looping forever
   requestAnimationFrame(animate);
+  updateGroundPatternPosition(ground, camera.position);
   renderer.render(scene, camera);
   recorder.captureFrame(renderer.domElement);
   fps.frame();

--- a/src/swift/public/js/scene.js
+++ b/src/swift/public/js/scene.js
@@ -8,6 +8,130 @@ import { resizeLines } from "./shapes.js";
 
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
+const GROUND_SIZE = 40;
+const GROUND_COLOR = 0x4b4b4b;
+
+// Set by setGroundPattern(), read by updateGroundPatternPosition() -- see
+// their doc comments below. No pattern active means no recentring, so the
+// plain flat floor keeps its original fixed-at-the-origin behaviour exactly.
+let groundTileWidth = null;
+let groundTileHeight = null;
+
+// A 2x2-pixel canvas, NearestFilter, repeated -- each pixel becomes one
+// checker square when magnified with no interpolation. Cheapest possible
+// seamless checkerboard, no drawing code needed beyond four pixels.
+function makeCheckerTexture() {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 2;
+  const ctx = canvas.getContext("2d");
+  const light = [0x8c, 0x8c, 0x8c, 255];
+  const dark = [0x2a, 0x2a, 0x2a, 255];
+  const imageData = ctx.createImageData(2, 2);
+  for (const [i, pixel] of [light, dark, dark, light].entries()) {
+    imageData.data.set(pixel, i * 4);
+  }
+  ctx.putImageData(imageData, 0, 0);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.magFilter = THREE.NearestFilter;
+  return texture;
+}
+
+// A single cell's border, drawn as a filled square with a stroked outline
+// -- one repeat of this canvas is exactly one grid cell.
+function makeGridTexture() {
+  const size = 64;
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "#4b4b4b";
+  ctx.fillRect(0, 0, size, size);
+  ctx.strokeStyle = "#8a8a8a";
+  ctx.lineWidth = 2;
+  ctx.strokeRect(0, 0, size, size);
+  return new THREE.CanvasTexture(canvas);
+}
+
+/**
+ * Applies (or clears) a repeating pattern on the ground plane's material.
+ *
+ * @param {THREE.Mesh} ground
+ * @param {THREE.Material} groundMaterial
+ * @param {boolean|string} pattern false clears any pattern (back to the
+ *   plain flat floor); true or "@tile" is a built-in checkerboard; "@grid"
+ *   is a built-in grid; anything else is a /retrieve/-servable texture path.
+ * @param {number} width x-extent of one tile, in metres -- the tile's
+ *   height follows the source image's own aspect ratio for a custom
+ *   texture (never distorted), or equals width for the built-ins (both
+ *   are square by construction).
+ */
+export function setGroundPattern(ground, groundMaterial, pattern, width) {
+  if (!pattern) {
+    groundMaterial.map = null;
+    groundMaterial.color.set(GROUND_COLOR);
+    groundMaterial.needsUpdate = true;
+    groundTileWidth = groundTileHeight = null;
+    ground.position.set(0, 0, 0);
+    return;
+  }
+
+  const applyRepeat = (texture, tileWidth, tileHeight) => {
+    texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+    texture.repeat.set(GROUND_SIZE / tileWidth, GROUND_SIZE / tileHeight);
+    groundMaterial.map = texture;
+    // The material's own color multiplies the texture -- white leaves the
+    // pattern's own colors (checker/grid/custom texture) unmodified;
+    // GROUND_COLOR would otherwise mute/darken all of them identically.
+    groundMaterial.color.set(0xffffff);
+    groundMaterial.needsUpdate = true;
+    groundTileWidth = tileWidth;
+    groundTileHeight = tileHeight;
+  };
+
+  if (pattern === true || pattern === "@tile") {
+    // One repeat of the 2x2-pixel canvas spans 2 squares per axis.
+    applyRepeat(makeCheckerTexture(), width * 2, width * 2);
+  } else if (pattern === "@grid") {
+    applyRepeat(makeGridTexture(), width, width);
+  } else {
+    // Mirrors loadMesh()'s own /retrieve/ URL construction (shapes.js) --
+    // same absolute-filesystem-path convention, same Windows adjustment.
+    let filename = pattern;
+    if (navigator.appVersion.indexOf("Win") !== -1) {
+      filename = filename.slice(2);
+    }
+    const url = "/retrieve" + encodeURI(filename);
+    new THREE.TextureLoader().load(
+      url,
+      (texture) => {
+        const aspect = texture.image.height / texture.image.width;
+        applyRepeat(texture, width, width * aspect);
+      },
+      undefined,
+      // No Python-side wait to fail for ground_pattern (unlike add_shape()'s
+      // shape_mounted poll) -- this is fire-and-forget, so a console error
+      // is the only signal available for a bad path/unsupported format.
+      (error) => console.error(`failed to load ground_pattern texture '${pattern}': ${error}`, error)
+    );
+  }
+}
+
+/**
+ * Keeps the ground plane's (finite) extent centred under the camera, so
+ * its edge is never reachable regardless of pan/zoom -- only meaningful
+ * once a pattern is active (see setGroundPattern()): a flat, untextured
+ * floor has no visible seam at its edge in the first place, so it's left
+ * exactly where it's always been rather than paying for this every frame.
+ *
+ * Snapped to the nearest whole tile so recentring never visibly shifts
+ * the pattern -- moving by an exact multiple of its own period looks
+ * identical to not having moved at all.
+ */
+export function updateGroundPatternPosition(ground, cameraPosition) {
+  if (groundTileWidth === null) return;
+  ground.position.x = Math.round(cameraPosition.x / groundTileWidth) * groundTileWidth;
+  ground.position.y = Math.round(cameraPosition.y / groundTileHeight) * groundTileHeight;
+}
+
 function addShadowedLight(scene, x, y, z, color, intensity) {
   const light = new THREE.DirectionalLight(color, intensity);
   light.position.set(x, y, z);
@@ -71,12 +195,12 @@ export function createScene() {
   // be set for opacity (see the "ground_opacity" message) to have any
   // effect at all -- three.js ignores opacity on an opaque material.
   const groundMaterial = new THREE.MeshPhongMaterial({
-    color: 0x4b4b4b,
+    color: GROUND_COLOR,
     specular: 0x101010,
     side: THREE.DoubleSide,
     transparent: true,
   });
-  const ground = new THREE.Mesh(new THREE.PlaneGeometry(40, 40), groundMaterial);
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(GROUND_SIZE, GROUND_SIZE), groundMaterial);
   ground.receiveShadow = true;
   scene.add(ground);
 
@@ -94,5 +218,5 @@ export function createScene() {
     resizeLines(window.innerWidth, window.innerHeight);
   });
 
-  return { scene, camera, renderer, controls, axesHelper, groundMaterial };
+  return { scene, camera, renderer, controls, axesHelper, ground, groundMaterial };
 }


### PR DESCRIPTION
## Summary
- `ground_pattern`: `False` (default, unchanged flat floor), `True`/`"@tile"` for a built-in checkerboard, `"@grid"` for a built-in grid, or any other string as an absolute path to a texture image (served the same way mesh files already are, via `/retrieve/`). `"@"` is deliberately not a valid leading character for a real file path, so the two built-in names and a custom texture path are distinguished with zero ambiguity and no extension-sniffing.
- `ground_pattern_width` sets the x-extent of one tile in metres; a custom texture's tile height follows its own image aspect ratio rather than being distorted to a square, and the built-ins are square by construction so this alone fully determines their size too.
- Introducing a real repeating pattern makes the ground plane's (current, always finite) edge much more visible than a flat colour's edge ever was -- so whenever a pattern is active, the ground now recentres under the camera every frame, snapped to a whole tile (moving by an exact multiple of the pattern's own period is visually identical to not moving at all, so this never shifts the pattern). Skipped entirely for the plain flat floor, which has no visible seam to begin with and loses nothing by staying exactly where it's always been.

## Test plan
- [x] `@tile` checkerboard -- confirmed clean tiling to the horizon at both close and far zoom, no visible edge (recentring working).
- [x] `@grid` -- confirmed a clean RViz/Gazebo-style floor grid, same recentring behaviour.
- [x] Custom non-square texture (2:1 aspect) at various `ground_pattern_width` values -- confirmed via an axis-aligned camera view that the tile's aspect ratio is preserved (not stretched to square).
- [x] `node --test src/swift/public/js/*.test.js` and `pytest tests/` -- all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)