### PR TITLE
fix: use spatialgeometry's correctly-spelled _propagate_scene_tree()

### DIFF
--- a/swift/Swift.py
+++ b/swift/Swift.py
@@ -224,7 +224,7 @@ class Swift:
 
         # Update world transform of objects
         for obj in self.swift_objects:
-            obj._propagate_scene_tree()
+            obj.update()
 
         # Adjust sim time
         self.sim_time += dt
@@ -353,7 +353,7 @@ class Swift:
         # list of robots which will act upon the step() method being called.
 
         if isinstance(ob, Shape):
-            ob._propagate_scene_tree()
+            ob.update()
             ob._added_to_swift = True
             if not self.headless:
                 id = int(self._send_socket("shape", [ob.to_dict()]))
@@ -391,7 +391,7 @@ class Swift:
 
             # Update robot transforms
             ob._update_link_tf()
-            ob._propagate_scene_tree()
+            ob.update()
 
             # Update robot qlim
             ob._qlim = ob.qlim

--- a/swift/Swift.py
+++ b/swift/Swift.py
@@ -224,7 +224,7 @@ class Swift:
 
         # Update world transform of objects
         for obj in self.swift_objects:
-            obj._propogate_scene_tree()
+            obj._propagate_scene_tree()
 
         # Adjust sim time
         self.sim_time += dt
@@ -353,7 +353,7 @@ class Swift:
         # list of robots which will act upon the step() method being called.
 
         if isinstance(ob, Shape):
-            ob._propogate_scene_tree()
+            ob._propagate_scene_tree()
             ob._added_to_swift = True
             if not self.headless:
                 id = int(self._send_socket("shape", [ob.to_dict()]))
@@ -391,7 +391,7 @@ class Swift:
 
             # Update robot transforms
             ob._update_link_tf()
-            ob._propogate_scene_tree()
+            ob._propagate_scene_tree()
 
             # Update robot qlim
             ob._qlim = ob.qlim


### PR DESCRIPTION
## Summary

`spatialgeometry`'s `_propogate_scene_tree()` was a plain misspelling of
"propagate" -- see [jhavl/spatialgeometry#38](https://github.com/jhavl/spatialgeometry/pull/38).
That PR was amended before merging: rather than landing a correctly-spelled
but still-private `_propagate_scene_tree()` only to deprecate it again
immediately after, it went straight to a public `update()` method.
`_propogate_scene_tree()` (the original misspelled name Swift called) remains
available as a deprecated (`FutureWarning`) alias for back-compat, but this
migrates Swift's 3 call sites (`Swift.py:227,356,394`) to call `update()`
directly instead.

## Test plan

- [x] `python -m py_compile swift/Swift.py` -- no syntax errors
- [x] Confirmed no remaining references to the old name
- [ ] Could not run a full live smoke test in this environment -- same
  pre-existing, unrelated NumPy 2.x/compiled-extension ABI issue on this
  branch's old flat layout noted in the previous commit's test plan. The
  change itself is a mechanical method-name substitution to a method
  confirmed to exist and behave correctly on the spatialgeometry branch
  (161/161 tests pass there).