### PR TITLE
feat: richer show()/__repr__(), plus __getitem__() lookup by id or name

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -197,9 +197,12 @@ class Swift:
     def _describe(self, i, obj):
         name = self.swift_names.get(i)
         if isinstance(obj, AssemblyHandle):
-            kind = "AssemblyHandle(robot)" if obj.robot is not None else "AssemblyHandle"
+            if obj.robot is not None:
+                kind = f"AssemblyHandle(robot={obj.robot.name!r}, links={len(obj.robot.links)})"
+            else:
+                kind = "AssemblyHandle"
         else:
-            kind = type(obj).__name__
+            kind = repr(obj)
         return f"[{i}] {kind}" + (f' "{name}"' if name else "")
 
     def __repr__(self):
@@ -209,17 +212,59 @@ class Swift:
             if ob is None:
                 continue
             s += f"\n  {self._describe(i, ob)}"
+            if isinstance(ob, AssemblyHandle) and ob.robot is not None:
+                for link in ob.robot.links:
+                    counts = []
+                    if len(link.geometry):
+                        counts.append(f"{len(link.geometry)} geometry")
+                    if len(link.collision):
+                        counts.append(f"{len(link.collision)} collision")
+                    suffix = f" ({', '.join(counts)})" if counts else ""
+                    s += f"\n      {link.name}{suffix}"
         return s
+
+    def __getitem__(self, key):
+        """
+        Retrieve a previously-added shape/robot/assembly by id or name.
+
+        ``env[3]`` retrieves by the id returned from ``add_shape()`` etc.
+        ``env["gripper"]`` retrieves by the ``name=`` given at add time --
+        only objects actually given a name are reachable this way.
+
+        :param key: the object's id, or its ``name=``
+        :type key: int | str
+        :raises KeyError: no object exists under ``key`` (never named,
+            already removed, or an out-of-range id)
+        """
+        if isinstance(key, str):
+            for i, name in self.swift_names.items():
+                if name == key and self.swift_objects[i] is not None:
+                    return self.swift_objects[i]
+            raise KeyError(f"no object named {key!r}")
+
+        try:
+            obj = self.swift_objects[key]
+        except IndexError:
+            obj = None
+        if obj is None:
+            raise KeyError(f"no object with id {key!r} (removed, or never existed)")
+        return obj
 
     def show(self):
         """
         Print the current display list, for debugging.
 
         ``env.show()`` prints every object currently added to the scene
-        (shapes, assemblies/robots, and UI elements) with its id, type,
-        and name if one was given via ``name=`` at add time. The
+        (shapes, assemblies/robots, and UI elements) with its id, a
+        ``repr()`` of the object itself, and its name if one was given
+        via ``name=`` at add time -- an assembly/robot also lists its
+        links, indented, with their geometry/collision shape counts. The
         pause/realtime-speed controls _add_controls() adds to every
         launch() aren't user-added UI, so they're excluded here too.
+
+        Any named object, or any object by its id, can also be
+        retrieved directly with ``env[name]`` / ``env[id]`` -- see
+        :meth:`__getitem__`.
         """
         print(repr(self))
         for eid, el in self.elements.items():

--- a/tests/test_display_list.py
+++ b/tests/test_display_list.py
@@ -1,0 +1,86 @@
+"""
+Tests for Swift's display list -- __repr__()/show()'s per-object
+description, and __getitem__() lookup by id or by name=.
+"""
+
+import pytest
+import roboticstoolbox as rtb
+import spatialgeometry as sg
+
+from swift import Swift
+
+
+def make_env():
+    env = Swift()
+    env.headless = True
+    return env
+
+
+def test_getitem_by_id_returns_the_same_object():
+    env = make_env()
+    shape = sg.Sphere(0.2)
+    id_ = env.add_shape(shape)
+
+    assert env[id_] is shape
+
+
+def test_getitem_by_name_returns_the_same_object():
+    env = make_env()
+    shape = sg.Sphere(0.2)
+    env.add_shape(shape, name="ball")
+
+    assert env["ball"] is shape
+
+
+def test_getitem_unnamed_object_not_reachable_by_any_name():
+    env = make_env()
+    env.add_shape(sg.Sphere(0.2))
+
+    with pytest.raises(KeyError):
+        env["ball"]
+
+
+def test_getitem_missing_name_raises_keyerror():
+    env = make_env()
+
+    with pytest.raises(KeyError):
+        env["nope"]
+
+
+def test_getitem_removed_id_raises_keyerror():
+    env = make_env()
+    id_ = env.add_shape(sg.Sphere(0.2))
+    env.remove(id_)
+
+    with pytest.raises(KeyError):
+        env[id_]
+
+
+def test_getitem_out_of_range_id_raises_keyerror():
+    env = make_env()
+
+    with pytest.raises(KeyError):
+        env[123]
+
+
+def test_describe_uses_shape_repr_not_bare_type_name():
+    env = make_env()
+    shape = sg.Sphere(0.2)
+    id_ = env.add_shape(shape)
+
+    assert env._describe(id_, shape) == f"[{id_}] {shape!r}"
+
+
+@pytest.mark.rtb
+def test_repr_lists_robot_links_indented_under_the_assembly():
+    env = make_env()
+    panda = rtb.models.Panda()
+    handle = env.add_robot(panda, name="panda")
+
+    text = repr(env)
+
+    assert f'"panda"' in text
+    for link in panda.links:
+        assert link.name in text
+    # links appear after (indented under) their AssemblyHandle line
+    assert text.index(panda.links[0].name) > text.index("AssemblyHandle")


### PR DESCRIPTION
## Summary

\`show()\` was spartan -- \`_describe()\` printed just the bare type name (\`Sphere\`), throwing away the informative \`repr()\` spatialgeometry's own \`Shape\` classes already provide. This:

- Swaps in \`repr(obj)\` instead of the type name.
- Lists an \`AssemblyHandle\`'s robot links, indented underneath it, with each link's geometry/collision shape counts.
- Adds \`env[id]\`/\`env["name"]\` (\`__getitem__\`) to retrieve a previously-added object directly. The integer id was already a stable handle -- \`remove()\` tombstones (\`swift_objects[idd] = None\`) rather than shifting the list -- this just adds a name-based lookup on top. No default name is assigned; only objects actually given a \`name=\` at add time are reachable by name, and a removed/unknown id or name raises \`KeyError\`.

## Test plan

- [x] New \`tests/test_display_list.py\` (8 tests): id/name lookup, missing-name/removed-id/out-of-range \`KeyError\`s, \`repr()\`-based description, robot-links indentation
- [x] Live smoke test: \`show()\`/\`env["name"]\` against a real (headless) session
- [x] Full suite unaffected (76 passed, 4 skipped, 8 pre-existing-or-expected unrelated failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)