### PR TITLE
feat: detect and warn on a stale browser-cached JS version

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -27,6 +27,9 @@ jobs:
           platforms: arm64
       - uses: actions/checkout@v3
 
+      - name: Sync JS version with pyproject.toml
+        run: python scripts/sync_js_version.py
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
 
@@ -39,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Sync JS version with pyproject.toml
+        run: python scripts/sync_js_version.py
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/scripts/sync_js_version.py
+++ b/scripts/sync_js_version.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""
+Patches comms.js's SWIFT_JS_VERSION constant to match pyproject.toml's
+version, in place. Run before packaging (see .github/workflows/
+cibuildwheel.yml) so every built wheel/sdist ships with a JS version
+string that's always correct for that exact release, with no manual
+sync step to forget.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+COMMS_JS = REPO_ROOT / "src" / "swift" / "public" / "js" / "comms.js"
+
+VERSION_PATTERN = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+CONSTANT_PATTERN = re.compile(r'export const SWIFT_JS_VERSION = "[^"]*";')
+
+
+def sync_js_version(pyproject_path: Path = PYPROJECT, comms_js_path: Path = COMMS_JS) -> str:
+    """
+    :param pyproject_path: defaults to this repo's own pyproject.toml --
+        overridable so tests can point at a throwaway fixture instead
+    :param comms_js_path: defaults to this repo's own comms.js -- same
+        reason
+    :returns: the version string comms_js_path was set to
+    :raises AssertionError: pyproject_path's version, or comms_js_path's
+        constant, couldn't be found -- fail loudly rather than silently
+        shipping a stale/wrong version
+    """
+    match = VERSION_PATTERN.search(pyproject_path.read_text())
+    assert match, f"couldn't find a version in {pyproject_path}"
+    version = match.group(1)
+
+    content = comms_js_path.read_text()
+    new_content, count = CONSTANT_PATTERN.subn(f'export const SWIFT_JS_VERSION = "{version}";', content)
+    assert count == 1, f"expected exactly 1 SWIFT_JS_VERSION constant in {comms_js_path}, found {count}"
+
+    comms_js_path.write_text(new_content)
+    return version
+
+
+if __name__ == "__main__":
+    print(f"SWIFT_JS_VERSION set to {sync_js_version()}")

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -16,6 +16,7 @@ import os
 from queue import Empty
 from http import HTTPStatus
 import urllib
+from importlib.metadata import version as _installed_version, PackageNotFoundError
 
 
 from queue import Queue
@@ -37,6 +38,55 @@ try:
     COLAB = True
 except ImportError:
     COLAB = False
+
+
+def _check_js_version(handshake_msg) -> None:
+    """
+    Warn if the connecting browser tab's JS reports a different version
+    than the currently-installed swift-sim package -- almost always a
+    stale, browser-cached page from before an upgrade. comms.js's
+    SWIFT_JS_VERSION is what makes this detectable at all: it's baked
+    into that file's own source (patched to match pyproject.toml at
+    release-build time -- see scripts/sync_js_version.py), so a stale
+    cached copy keeps reporting whatever version was true when it was
+    cached, not the current one.
+
+    :param handshake_msg: the raw first message received over the
+        websocket, expected to be JSON containing "js_version" -- a
+        pre-version-reporting JS build just sends the bare string
+        "Connected" instead, which fails to parse and is treated the
+        same as "no version reported at all"
+    """
+    try:
+        installed = _installed_version("swift-sim")
+    except PackageNotFoundError:
+        # Editable/dev install with no dist-info to compare against --
+        # nothing meaningful to warn about.
+        return
+
+    js_version = None
+    try:
+        payload = json.loads(handshake_msg)
+        if isinstance(payload, dict):
+            js_version = payload.get("js_version")
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    if js_version is None:
+        print(
+            "\nWarning: this browser tab appears to be running a very "
+            "old, cached copy of Swift's JavaScript -- older than the "
+            f"version that added version reporting -- while swift-sim "
+            f"{installed} is installed. If anything looks broken, "
+            "hard-refresh the browser tab (or open a new one).\n"
+        )
+    elif js_version != installed:
+        print(
+            f"\nWarning: this browser tab is running Swift JS v{js_version}, "
+            f"but swift-sim v{installed} is installed -- likely a stale "
+            "cached page. Hard-refresh the browser tab (or open a new "
+            "one) to pick up the current version.\n"
+        )
 
 
 def start_servers(
@@ -143,7 +193,7 @@ def start_servers(
     # auto-opening -- give them realistic time to notice and click it.
     handshake_timeout = 60 if COLAB else 10
     try:
-        inq.get(timeout=handshake_timeout)
+        handshake_msg = inq.get(timeout=handshake_timeout)
     except Empty:
         if COLAB:
             print(
@@ -157,6 +207,8 @@ def start_servers(
         else:
             print("\nCould not connect to the Swift simulator \n")
         raise
+
+    _check_js_version(handshake_msg)
 
     return socket, socket_instance, server, server_instance, notebook_handle
 

--- a/src/swift/public/js/comms.js
+++ b/src/swift/public/js/comms.js
@@ -12,6 +12,21 @@
  * dispatch table.
  */
 
+// Patched in place to match pyproject.toml's `version` before every
+// release build -- see scripts/sync_js_version.py, run as a step in
+// .github/workflows/cibuildwheel.yml, so this can never drift out of
+// sync via a forgotten manual bump. The value checked in here is only
+// what a local editable install/dev checkout sees.
+//
+// Baked directly into this source file (not injected at serve time) so
+// that a *stale, browser-cached* copy of this exact file still reports
+// whatever version was true when it was cached -- that's the whole
+// point: SwiftRoute.py's start_servers() compares this against the
+// currently-installed package version at connection time, so a browser
+// tab running old cached JS against a freshly-upgraded install gets a
+// clear warning instead of silently misbehaving.
+export const SWIFT_JS_VERSION = "2.0.0";
+
 export class WebSocketTransport {
   /** @param {string} url */
   constructor(url) {

--- a/src/swift/public/js/main.js
+++ b/src/swift/public/js/main.js
@@ -1,7 +1,7 @@
 import { createScene, setGroundPattern, updateGroundPatternPosition, setLights } from "./scene.js";
 import { SwiftObject } from "./shapes.js";
 import { Slider, Button, Label, Select, Checkbox, Radio } from "./ui.js";
-import { WebSocketTransport, portFromLocation } from "./comms.js";
+import { WebSocketTransport, portFromLocation, SWIFT_JS_VERSION } from "./comms.js";
 import { Recorder } from "./recording.js";
 import { FPS, SimTime } from "./hud.js";
 
@@ -58,7 +58,13 @@ const transport = new WebSocketTransport(`ws://localhost:${portFromLocation()}/`
 let connected = false;
 
 transport.onOpen(() => {
-  transport.send("Connected");
+  // Plain JSON, not one of main.js's own [func, data] wire-protocol
+  // pairs -- this is the very first message, before Python's read loop
+  // has even started dispatching those; SwiftRoute.py's start_servers()
+  // reads it directly to check this tab's JS version against the
+  // installed package's, so it can warn about a stale browser cache
+  // rather than something more confusing further down the line.
+  transport.send(JSON.stringify({ event: "connected", js_version: SWIFT_JS_VERSION }));
   connected = true;
   requestAnimationFrame(animate);
 });

--- a/tests/test_js_version_check.py
+++ b/tests/test_js_version_check.py
@@ -1,0 +1,62 @@
+"""
+Tests for SwiftRoute._check_js_version() -- warns when a connecting
+browser tab's JS handshake reports a different (or no) version than the
+currently-installed swift-sim package, which almost always means a
+stale browser cache surviving a pip upgrade.
+"""
+
+import json
+
+import pytest
+
+from swift.SwiftRoute import _check_js_version
+
+
+@pytest.fixture(autouse=True)
+def installed_version(monkeypatch):
+    monkeypatch.setattr("swift.SwiftRoute._installed_version", lambda pkg: "2.0.0")
+
+
+def test_matching_version_prints_nothing(capsys):
+    _check_js_version(json.dumps({"event": "connected", "js_version": "2.0.0"}))
+
+    assert capsys.readouterr().out == ""
+
+
+def test_mismatched_version_warns_with_both_versions(capsys):
+    _check_js_version(json.dumps({"event": "connected", "js_version": "1.9.0"}))
+
+    out = capsys.readouterr().out
+    assert "1.9.0" in out
+    assert "2.0.0" in out
+    assert "stale" in out
+
+
+def test_pre_version_reporting_handshake_warns_as_very_old(capsys):
+    # A JS build from before this feature existed just sends the bare
+    # string "Connected" -- not valid JSON at all.
+    _check_js_version("Connected")
+
+    out = capsys.readouterr().out
+    assert "very old" in out
+    assert "2.0.0" in out
+
+
+def test_json_handshake_missing_js_version_key_also_warns_as_very_old(capsys):
+    _check_js_version(json.dumps({"event": "connected"}))
+
+    out = capsys.readouterr().out
+    assert "very old" in out
+
+
+def test_dev_install_with_no_dist_info_prints_nothing(capsys, monkeypatch):
+    from importlib.metadata import PackageNotFoundError
+
+    def raise_not_found(pkg):
+        raise PackageNotFoundError(pkg)
+
+    monkeypatch.setattr("swift.SwiftRoute._installed_version", raise_not_found)
+
+    _check_js_version("Connected")
+
+    assert capsys.readouterr().out == ""

--- a/tests/test_sync_js_version.py
+++ b/tests/test_sync_js_version.py
@@ -1,0 +1,90 @@
+"""
+Tests for scripts/sync_js_version.py -- the release-build step that
+patches comms.js's SWIFT_JS_VERSION constant to match pyproject.toml,
+so the two can never silently drift.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from sync_js_version import sync_js_version  # noqa: E402
+
+
+def _write_fixture(tmp_path, version, constant_value):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(f'[project]\nname = "swift-sim"\nversion = "{version}"\n')
+
+    comms_js = tmp_path / "comms.js"
+    comms_js.write_text(
+        "/** some header comment */\n"
+        f'export const SWIFT_JS_VERSION = "{constant_value}";\n'
+        "\nexport class WebSocketTransport {}\n"
+    )
+    return pyproject, comms_js
+
+
+def test_patches_a_mismatched_constant(tmp_path):
+    pyproject, comms_js = _write_fixture(tmp_path, version="3.1.4", constant_value="0.0.0")
+
+    result = sync_js_version(pyproject_path=pyproject, comms_js_path=comms_js)
+
+    assert result == "3.1.4"
+    assert 'export const SWIFT_JS_VERSION = "3.1.4";' in comms_js.read_text()
+
+
+def test_is_a_no_op_when_already_in_sync(tmp_path):
+    pyproject, comms_js = _write_fixture(tmp_path, version="2.0.0", constant_value="2.0.0")
+    before = comms_js.read_text()
+
+    sync_js_version(pyproject_path=pyproject, comms_js_path=comms_js)
+
+    assert comms_js.read_text() == before
+
+
+def test_preserves_everything_else_in_the_file(tmp_path):
+    pyproject, comms_js = _write_fixture(tmp_path, version="1.2.3", constant_value="1.0.0")
+
+    sync_js_version(pyproject_path=pyproject, comms_js_path=comms_js)
+
+    content = comms_js.read_text()
+    assert "/** some header comment */" in content
+    assert "export class WebSocketTransport {}" in content
+
+
+def test_raises_if_pyproject_has_no_version(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "swift-sim"\n')
+    comms_js = tmp_path / "comms.js"
+    comms_js.write_text('export const SWIFT_JS_VERSION = "0.0.0";\n')
+
+    with pytest.raises(AssertionError, match="couldn't find a version"):
+        sync_js_version(pyproject_path=pyproject, comms_js_path=comms_js)
+
+
+def test_raises_if_comms_js_has_no_constant(tmp_path):
+    pyproject, comms_js = _write_fixture(tmp_path, version="1.0.0", constant_value="1.0.0")
+    comms_js.write_text("export class WebSocketTransport {}\n")
+
+    with pytest.raises(AssertionError, match="expected exactly 1"):
+        sync_js_version(pyproject_path=pyproject, comms_js_path=comms_js)
+
+
+def test_the_real_repo_files_are_actually_in_sync():
+    # Read-only check against the real files (never calls sync_js_version()
+    # itself here -- that writes, and a test shouldn't mutate real repo
+    # source as a side effect even when the write would be a no-op). This
+    # is what would actually catch a forgotten manual bump in local dev,
+    # before a release build's automatic patch ever runs.
+    from sync_js_version import COMMS_JS, CONSTANT_PATTERN, PYPROJECT, VERSION_PATTERN
+
+    version = VERSION_PATTERN.search(PYPROJECT.read_text()).group(1)
+    constant_line = CONSTANT_PATTERN.search(COMMS_JS.read_text())
+
+    assert constant_line is not None, f"no SWIFT_JS_VERSION constant found in {COMMS_JS}"
+    assert constant_line.group() == f'export const SWIFT_JS_VERSION = "{version}";', (
+        "comms.js's SWIFT_JS_VERSION doesn't match pyproject.toml's version -- "
+        "run `python scripts/sync_js_version.py` and commit the result"
+    )


### PR DESCRIPTION
## Summary

Users who've upgraded `swift-sim` can still have an old, browser-cached copy of the frontend JS -- `Cache-Control: no-store` only protects responses served *after* that fix landed, and swift's dev server tends to reuse the same handful of low ports across runs, so a stale cache entry from before an upgrade can resurface indefinitely and silently misbehave against a newer Python package.

- `comms.js` now sends a version string (`SWIFT_JS_VERSION`) as part of the initial `"connected"` WebSocket handshake -- baked directly into that file's own source, not injected at serve time, so a *stale cached copy* keeps reporting whatever version was true when it was cached. That's the exact fingerprint needed to detect it.
- `SwiftRoute.py`'s `start_servers()` compares this against the installed `swift-sim` package version and prints a clear warning on mismatch -- including the "no version at all" case (a page cached from *before* this feature existed), treated explicitly as "very old" rather than a parse error.
- `scripts/sync_js_version.py` patches the constant to match `pyproject.toml`'s version automatically before every release build (wired into both jobs in `.github/workflows/cibuildwheel.yml`) -- no manual bump to forget, so this can never silently drift for a real release.

## Test plan

- [x] `tests/test_sync_js_version.py` (6 tests): patches a mismatched constant, no-op when already in sync, preserves surrounding file content, raises clearly on a missing version/constant, and a read-only check that the real checked-in files are actually in sync right now
- [x] `tests/test_js_version_check.py` (5 tests): matching version is silent, mismatched version warns with both versions, a pre-version-reporting bare `"Connected"` handshake warns as "very old", a JSON handshake missing the key does too, and an editable/dev install with no dist-info is silent
- [x] Rehearsed the actual release-build step locally: ran `scripts/sync_js_version.py` + `python -m build --sdist`, then inspected the built `.tar.gz` directly to confirm the shipped `comms.js` carries the correct version
- [x] Live end-to-end: a real browser tab, with the installed package version mocked to differ, produces the exact expected warning
- [x] Full suite unaffected (87 passed, 4 skipped, 8 deselected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)