### PR TITLE
fix: use spatialgeometry's renamed Polyline instead of deprecated Path

### DIFF
--- a/src/swift/public/js/shapes.js
+++ b/src/swift/public/js/shapes.js
@@ -222,8 +222,11 @@ function loadAxes(part, scene, cb) {
 }
 
 /**
- * spatialgeometry.Path: a polyline through a sequence of waypoints --
- * straight segments joining consecutive points, not a smoothed curve.
+ * spatialgeometry.Polyline (renamed from Path to avoid clashing with
+ * pathlib.Path -- jhavl/spatialgeometry#42; the wire-protocol stype
+ * string below deliberately stayed "path", see the dispatch site in
+ * load()): a polyline through a sequence of waypoints -- straight
+ * segments joining consecutive points, not a smoothed curve.
  * radius == 0 renders as a single screen-space-width Line2 (mirrors
  * Arrow's line-mode shaft, connecting every point in sequence); radius > 0
  * renders as a real tube built from a CurvePath of straight LineCurve3
@@ -477,6 +480,10 @@ function load(part, scene, cb, errCb) {
   else if (["cuboid", "box", "sphere", "cylinder", "ellipsoid"].includes(part.stype)) loadPrimitive(part, scene, cb);
   else if (part.stype === "axes") loadAxes(part, scene, cb);
   else if (part.stype === "arrow") loadArrow(part, scene, cb);
+  // "path" is spatialgeometry.Polyline's stype (not "polyline") -- the
+  // Python class was renamed (avoids clashing with pathlib.Path), but
+  // the wire string deliberately wasn't, to avoid a breaking protocol
+  // change for a rename that's purely cosmetic on the Python side.
   else if (part.stype === "path") loadPath(part, scene, cb);
   else {
     const reason = `unsupported shape type '${part.stype}'`;

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -97,7 +97,13 @@ def test_add_path_sends_points_radius_and_linewidth():
     browser = FakeBrowser(env, responses=["0", json.dumps([1, None])])
 
     points = np.array([[0.0, 1.0, 2.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
-    path = sg.Path(points, radius=0.02, linewidth=2.0, color=[1.0, 0.0, 0.0, 1.0])
+    # spatialgeometry renamed the Python class Path -> Polyline (avoids
+    # clashing with pathlib.Path -- see jhavl/spatialgeometry#42), but
+    # deliberately left the wire-protocol stype string as "path" --
+    # changing that too would be a breaking protocol change requiring a
+    # matching shapes.js update, for a rename that's purely cosmetic on
+    # the Python side.
+    path = sg.Polyline(points, radius=0.02, linewidth=2.0, color=[1.0, 0.0, 0.0, 1.0])
     env.add(path)
 
     _, shape_data = browser.received[0]


### PR DESCRIPTION
## Summary

spatialgeometry renamed the Python class `Path` -> `Polyline` (avoids clashing with `pathlib.Path` -- jhavl/spatialgeometry#42), keeping `Path` around as a deprecated (`FutureWarning`) alias.

Migrates swift's one direct reference to the old name (`tests/test_protocol.py`). The wire-protocol `stype` string deliberately stays `"path"` -- changing that too would be a breaking protocol change requiring a matching `shapes.js` update, for a rename that's purely cosmetic on the Python side -- so `shapes.js` just gained comments explaining the naming disparity at both the class-level doc comment and the `stype === "path"` dispatch site, not a code change.

## Test plan

- [x] Full suite passes (76 passed, 4 skipped, 8 deselected)
- [x] Confirmed no `FutureWarning` fires anymore: reran the affected test with `-W error::FutureWarning`, still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)