### PR TITLE
feat: SWIFT_HEADLESS env var as launch()'s headless default

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -280,7 +280,7 @@ class Swift:
     def launch(
         self,
         realtime: bool | float = False,
-        headless: bool = False,
+        headless: bool | None = None,
         rate: int = 60,
         browser: str | None = None,
         axes: bool = True,
@@ -351,8 +351,13 @@ class Swift:
         :type realtime: bool | float
         :param headless: Do not launch the graphical front-end of the
             simulator. Will still simulate the robot. Runs faster due to not
-            needing to display anything.
-        :type headless: bool
+            needing to display anything. ``None`` (default) falls back to
+            the ``SWIFT_HEADLESS`` environment variable (headless if set to
+            any non-empty value), then ``False`` if that's also unset --
+            lets a test harness or CI environment force headless mode
+            globally without every calling script having to pass
+            ``headless=True`` itself.
+        :type headless: bool | None
         :param rate: The rate (Hz) at which the simulator will be run,
             defaults to 60Hz
         :type rate: int
@@ -415,6 +420,8 @@ class Swift:
             self.realtime_speed = 1.0 if realtime else None
         else:
             self.realtime_speed = float(realtime)
+        if headless is None:
+            headless = bool(os.environ.get("SWIFT_HEADLESS"))
         self.headless = headless
         self.axes = axes
         self.ground_opacity = ground_opacity
@@ -483,7 +490,7 @@ class Swift:
             # event loop to return.
             self.socket.stop()
             self.socket_thread.join(1)
-        if not self._dev:
+        if not self._dev and not self.headless:
             # server.stop() (httpd.shutdown()) is what actually lets
             # serve_forever() return -- without it, Thread.run() never
             # reaches its own cleanup of the arguments it was started
@@ -517,6 +524,10 @@ class Swift:
             - The control type is defined by the robot object, and not all
               robot objects support all control types.
             - Execution is blocked for the specified interval
+
+        :seealso: :meth:`run` for repeatedly calling this in a loop with
+            disconnect-awareness built in, instead of hand-writing
+            ``while True: env.step(dt)``.
 
         """
 
@@ -1067,6 +1078,9 @@ class Swift:
             ``None`` never gives up on a disconnect (still stops at
             ``duration``, if given).
         :type timeout: float | None
+
+        :seealso: :meth:`step` for a single manual update, if you need
+            finer control than a bounded/unbounded loop gives you.
         """
 
         if timeout is None:


### PR DESCRIPTION
## Summary
- `launch()`'s `headless` param defaults to `None`, resolving to the `SWIFT_HEADLESS` env var (headless if set to any non-empty value) when not passed explicitly, `False` otherwise -- same shape as `MPLBACKEND`/`QT_QPA_PLATFORM`. Lets a CI/test harness force headless globally without every calling script passing `headless=True`.
- Fixes a real bug found while exercising the new path end-to-end: `_stop_threads()` guarded `self.socket.stop()` on `not self.headless` but not the `self.server.stop()` call just below it -- `self.server` is only ever assigned `if not self.headless` in `launch()`, so `close()` unconditionally crashed with `AttributeError` for any headless session.
- Added `:seealso:` cross-references between `step()` and `run()`'s docstrings.

Motivated by needing reliable headless smoke tests for graphics-driven demo scripts over in robotics-toolbox-python.

## Test plan
- [x] `SWIFT_HEADLESS=1` + `launch()` with no explicit `headless` arg -> `env.headless == True`, `step()` and `close()` both complete cleanly (previously `close()` crashed)
- [x] Explicit `headless=True`/`False` still overrides the env var as before
- [x] Full test suite: 90/91 pass (1 pre-existing failure, `spatialgeometry.Polyline` missing in this env's installed version -- unrelated to this change)