### PR TITLE
fix: CI test collection failure + spatialgeometry Path->Polyline gap

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -40,9 +40,22 @@ jobs:
         # developed together across git branches, ahead of what's actually
         # released -- see jhavl/swift#88). Installing from that branch
         # directly, same idea as installing swift-sim itself from source
-        # below. spatialgeometry is listed explicitly so it isn't left to
-        # whatever roboticstoolbox-python's own pin happens to resolve to.
-        run: pip install "git+https://github.com/petercorke/robotics-toolbox-python.git@feat/fkine-geometry" spatialgeometry websockets pytest pytest-cov black flake8 pyyaml
+        # below.
+        run: pip install "git+https://github.com/petercorke/robotics-toolbox-python.git@feat/fkine-geometry" websockets pytest pytest-cov black flake8 pyyaml
+
+      - name: Install spatialgeometry from its own main branch
+        # main renamed Path -> Polyline (jhavl/spatialgeometry#42, merged
+        # 2026-08-09) but that hasn't been cut into a PyPI release yet --
+        # PyPI's latest (1.3.0) predates the rename and tests/ constructs
+        # sg.Polyline(...) directly, so the plain PyPI spatialgeometry that
+        # roboticstoolbox-python pulled in above fails with AttributeError.
+        # A separate --force-reinstall --no-deps step (rather than listing
+        # this alongside roboticstoolbox-python above) sidesteps a pip
+        # resolver conflict: roboticstoolbox-python's own metadata pins
+        # spatialgeometry==1.3.0 exactly, which collides with requesting
+        # the git version under that same version string. Switch this back
+        # to a plain PyPI pin once a release containing the rename ships.
+        run: pip install --force-reinstall --no-deps "git+https://github.com/jhavl/spatialgeometry.git@main"
 
       - name: Install swift-sim itself (editable, no dependency re-resolution)
         run: pip install --no-build-isolation --no-deps -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,13 @@ packages = ["swift"]
 markers = ["rtb: requires roboticstoolbox to build a real robot model"]
 addopts = "-m 'not rtb'"
 
+# tests/test_lights.py imports fixtures from tests/test_protocol.py as
+# `tests.test_protocol`, which needs the repo root on sys.path. That's
+# implicit when running via `python -m pytest` (which prepends cwd) but
+# not for a bare `pytest` invocation -- which is what CI's workflow uses,
+# so every CI run has been failing at collection since this landed.
+pythonpath = ["."]
+
 [tool.black]
 
 line-length = 88


### PR DESCRIPTION
## Summary

CI's Python-tests workflow has failed on every run since 2026-08-07/09 (PRs #113 through #122), unrelated to what any of those PRs actually changed. Two independent issues, both fixed here:

- **Collection failure (the one causing every visible CI failure):** `tests/test_lights.py` imports fixtures via `from tests.test_protocol import ...`, which needs the repo root on `sys.path`. That's implicit under `python -m pytest` (which prepends cwd) but not for a bare `pytest` invocation — which is what this workflow uses. Fixed with `pythonpath = ["."]` in `pyproject.toml`'s pytest config, pytest's native mechanism for this (no plugin, no `tests/__init__.py` needed).
- **A real failure this was masking:** once collection succeeds, `tests/test_protocol.py::test_add_path_sends_points_radius_and_linewidth` fails with `AttributeError: module 'spatialgeometry' has no attribute 'Polyline'`. spatialgeometry's `Path -> Polyline` rename (jhavl/spatialgeometry#42) merged to its `main` branch on 2026-08-09, after the last PyPI release (1.3.0) shipped on 2026-08-03 — so plain `pip install spatialgeometry` in CI doesn't have it yet. Pinned CI to `spatialgeometry@main` instead, mirroring the existing roboticstoolbox-python workaround already in this same workflow file for the identical reason.

Confirmed this isn't masking any other breakage: diffed spatialgeometry `main` against the `v1.3.0` tag, and swift's own `src/` doesn't touch any of the other API changes in that range (`set_alpha`→`opacity`, `Mesh.filename`/`y_up` read-only, etc.). `Path` itself still works unchanged on `main` — it's kept as a subclass of `Polyline` that just emits a `FutureWarning`. Swift's full test suite (91 default + 8 `rtb`-marked) passes against spatialgeometry `main` + roboticstoolbox-python `feat/fkine-geometry`.

## Test plan

- [x] `pytest tests/ -v` (bare invocation, matching CI) passes: 91 passed, 8 deselected
- [x] `pytest tests/ -v -m rtb` passes: 8 passed
- [x] Verified in a clean venv mirroring CI's exact install sequence (roboticstoolbox-python from git, spatialgeometry force-reinstalled from git, swift-sim editable install)
