### PR TITLE
feat: add swift.__version__

### DIFF
--- a/src/swift/__init__.py
+++ b/src/swift/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from swift.SwiftRoute import SwiftServer, SwiftSocket, start_servers
 from swift.SwiftElement import (
     SwiftElement,
@@ -19,7 +21,15 @@ from swift.Light import (
     SpotLight,
 )
 
+try:
+    __version__ = version("swift-sim")
+except PackageNotFoundError:
+    # running from a source checkout without an installed/editable
+    # swift-sim distribution -- e.g. importing straight from src/
+    __version__ = "unknown"
+
 __all__ = [
+    "__version__",
     "Swift",
     "SwiftServer",
     "SwiftSocket",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,22 @@
+"""
+Tests for swift.__version__ -- installed via importlib.metadata off the
+swift-sim distribution, so it always matches whatever was actually built,
+with no separate constant to fall out of sync.
+"""
+
+import re
+from pathlib import Path
+
+import swift
+
+
+def test_version_is_a_non_empty_string():
+    assert isinstance(swift.__version__, str)
+    assert swift.__version__
+
+
+def test_version_matches_pyproject():
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE)
+    assert match, f"couldn't find a version in {pyproject}"
+    assert swift.__version__ == match.group(1)


### PR DESCRIPTION
## Summary

- Add `swift.__version__`, read off the installed `swift-sim` distribution via `importlib.metadata`, same pattern already used by sibling repo spatialmath-python.
- Falls back to `"unknown"` if imported from a source checkout with no installed/editable distribution.

## Test plan

- [x] `python -c "import swift; print(swift.__version__)"` → `2.0.0`, matching `pyproject.toml`
- [x] New `tests/test_version.py`: asserts it's a non-empty string and matches `pyproject.toml`'s `version`
- [x] Full suite passes (aside from the pre-existing, unrelated `spatialgeometry` Polyline gap fixed in #123, present here only because my local env predates that fix)
