### PR TITLE
fix: point dependabot's npm directory at the new src/ layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   # running `npm run build:vendor` and reviewing the diff; Dependabot
   # only opens the PR, it doesn't refresh the vendored files itself.
   - package-ecosystem: "npm"
-    directory: "/swift/public"
+    directory: "/src/swift/public"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

\`/swift/public/package.json\` no longer exists after the \`src/\` layout move (#125) — dependabot's scheduled npm update job for that directory started failing outright (\`package.json not found\`, confirmed in the actual failed run). Points it at the real path, \`src/swift/public\`.

## Test plan

- [x] Confirmed \`src/swift/public/package.json\` exists at the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)