### PR TITLE
fix: bump manylinux images to 2_28, add fail-fast: false to wheel matrix

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,8 @@ extend-ignore = 'E203'
 # test-requires = "pytest"
 # test-command = "pytest {project}/tests"
 
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 # Build CPython
 build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]


### PR DESCRIPTION
## Summary

The `v2.0.0rc1` rehearsal's Linux wheel builds failed. NumPy is a build-time dependency here (setup.py's C extension needs its headers), and the `manylinux2014` container has no matching prebuilt NumPy 2 wheel to install, so pip tried compiling NumPy from source instead — which then failed because NumPy's own build needs a newer GCC than that container ships.

Checked PyPI directly: NumPy 2.5.2's actual published wheels for x86_64/aarch64 are tagged `manylinux_2_27`/`manylinux_2_28`, nothing for `manylinux2014`. Bumping `manylinux-x86_64-image`/`manylinux-aarch64-image` to `manylinux_2_28` means pip finds and installs that real prebuilt wheel instead of falling back to a from-source build at all — this removes the GCC-version problem entirely, rather than working around it.

Also adds `fail-fast: false` to the wheel-build matrix — the rc1 run's `ubuntu-24.04-arm` failure cancelled the other three (otherwise fine) platform builds via GitHub's default fail-fast cascade, which made the actual failure harder to diagnose than it needed to be.

## Test plan

- [x] Verified NumPy 2.5.2's published wheel tags directly against PyPI's JSON API (no `manylinux2014` wheels exist for x86_64/aarch64)
- [ ] Re-cut `v2.0.0rc1` (or `rc2`) after merge and confirm all 4 platforms build + `upload_pypi` succeeds