### PR TITLE
fix: legacy robot.q/qd mutation never wrote handle's integration back

### DIFF
--- a/src/swift/Handle.py
+++ b/src/swift/Handle.py
@@ -118,3 +118,29 @@ class AssemblyHandle:
         self._model_q = self.q.copy()
         self._model_qd = self.qd.copy()
         self._model_control_mode = self._control_mode
+
+    def _push_legacy(self):
+        """
+        Mirror image of :meth:`_sync_legacy`. Once a handle has been
+        confirmed to be in the deprecated direct-mutation style
+        (``self._warned``), Swift's own internal updates to
+        ``handle.q``/``handle.qd`` -- e.g. velocity-mode integration in
+        ``Swift._step_assembly`` -- need to reach back into
+        ``robot.q``/``robot.qd`` too, or a control loop that reads
+        ``robot.q`` back after ``env.step()`` (the common pattern, e.g.
+        RTB's own README p_servo example) sees a permanently stale value
+        and never converges.
+
+        Only ever touches the robot once ``_warned`` is set, so a handle
+        never driven the legacy way -- the intended case, and the one
+        where several handles may share one plain, stateless robot model
+        -- never has its q/qd silently overwritten by this.
+        """
+        if self.robot is None or not self._warned:
+            return
+
+        self.robot._q = self.q.copy()
+        self.robot._qd = self.qd.copy()
+        self._model_q = self.q.copy()
+        self._model_qd = self.qd.copy()
+        self._model_control_mode = self._control_mode

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -1270,6 +1270,7 @@ class Swift:
 
             robot = handle.robot
             step_v(robot._n, robot._valid_qlim, dt, handle.q, handle.qd, robot._qlim)
+            handle._push_legacy()
 
         elif handle.control_mode == "a":
             pass

--- a/tests/test_assembly_handle.py
+++ b/tests/test_assembly_handle.py
@@ -77,6 +77,38 @@ def test_legacy_direct_mutation_still_works_but_warns_once():
 
 
 @pytest.mark.rtb
+def test_legacy_qd_mutation_updates_robot_q_after_step():
+    """
+    A control loop driving the deprecated robot.qd style (e.g. RTB's own
+    README p_servo example) needs robot.q to reflect Swift's own per-step
+    integration afterwards, or it's stuck reading a permanently stale
+    configuration and never converges. See jhavl/swift#125.
+    """
+    env = make_env()
+    panda = rtb.models.Panda()
+    panda.q = panda.qr
+    env.add_robot(panda)
+
+    q_before = panda.q.copy()
+
+    with pytest.warns(DeprecationWarning):
+        panda.qd = np.full(panda.n, 0.1)
+        env.step(0.05)
+
+    assert np.allclose(panda.q, q_before + 0.1 * 0.05)
+
+    # Second step: no further warning, q keeps advancing from where it
+    # left off (not re-integrated from the stale pre-loop value).
+    q_before = panda.q.copy()
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        panda.qd = np.full(panda.n, 0.1)
+        env.step(0.05)
+    assert len(record) == 0
+    assert np.allclose(panda.q, q_before + 0.1 * 0.05)
+
+
+@pytest.mark.rtb
 def test_new_style_usage_never_warns():
     env = make_env()
     panda = rtb.models.Panda()


### PR DESCRIPTION
## Summary

`_sync_legacy()` only pulled `robot.q`/`robot.qd` -> `handle.q`/`handle.qd` (detecting the deprecated direct-mutation style and adopting it), but never pushed Swift's own per-step integration (velocity-mode `step_v()`) back into `robot.q`/`robot.qd`.

A control loop that reads `robot.q` back mid-loop -- the normal pattern, and RTB's own documented README example -- saw a permanently stale configuration: `fkine()`/`jacobe()` never advanced, so the computed `qd` never changed either, and the robot just ran the same joint velocity forever without converging or stopping. Not just a deprecation-warning nuisance -- a silent functional break with no error.

Reproduced RTB's exact README p_servo example headlessly:
- **Without this fix:** hits a 500-step cap, never arrives, `panda.q` frozen at the initial value the entire time.
- **With this fix:** converges in 43 steps.

## Fix

Added `_push_legacy()`, the mirror of `_sync_legacy()`: once a handle is confirmed to be in legacy mode (`_warned`), write `handle.q`/`handle.qd` back into `robot._q`/`robot._qd` after each `step_v()` integration, keeping the snapshot in sync so this doesn't retrigger the warning.

Gated on `_warned` (not unconditional) so a handle never driven the legacy way -- the intended case, including several handles sharing one plain robot model -- is untouched, preserving the actual design goal of the refactor.

Companion RTB PRs:
- `docs: update Swift RRMC example to the AssemblyHandle API` (README + `examples/RRMC_swift.py`)
- `fix: Robot._to_dict() uses set_alpha(), deprecated by spatialgeometry`

## Test plan

- [x] New test `test_legacy_qd_mutation_updates_robot_q_after_step`: drives `panda.qd` directly across two `env.step()` calls, asserts `panda.q` advances correctly and only warns once
- [x] Full suite passes (91 default + 9 `rtb`-marked; one pre-existing, unrelated `spatialgeometry` Polyline gap from a stale local install, not this change)
- [x] Manual repro of RTB's exact README example, headless, before/after
