### PR TITLE
fix: disconnect during reply wait falls through to full _REPLY_TIMEOUT

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -9,6 +9,7 @@ import spatialmath as sm
 from spatialgeometry import Shape
 import time
 from queue import Queue, Empty
+from threading import Event
 import json
 from swift import start_servers, SwiftElement, Button, Select
 from swift.Handle import AssemblyHandle
@@ -71,6 +72,12 @@ _REALTIME_SPEEDS = [None, 1.0, 0.5, 0.25]
 # (closed, crashed, or dropped into a different window/profile mid-drag,
 # see bugs.md) rather than being legitimately busy.
 _REPLY_TIMEOUT = 15
+
+# How often _send_socket() re-checks for a server-detected disconnect while
+# waiting for a reply -- short enough that a disconnect mid-wait (the
+# common case during an active step() loop) ends the wait almost
+# immediately, rather than only ever bailing out at _REPLY_TIMEOUT.
+_DISCONNECT_POLL_INTERVAL = 0.05
 
 rtb = None
 
@@ -184,6 +191,14 @@ class Swift:
         self._browser_timeout = 5
         # Set by launch(browser="notebook") -- see close()'s clear_cell=.
         self._notebook_display_handle = None
+        # Set by SwiftSocket the instant a disconnect is detected server-
+        # side -- lets _send_socket()'s wait bail out well before
+        # _REPLY_TIMEOUT. Cleared again at the top of launch(), not
+        # recreated -- close()/launch() (the documented reconnect path)
+        # don't call _init() again, so the same Event persists and must
+        # be explicitly re-armed rather than left set from a prior
+        # session's disconnect.
+        self._disconnected = Event()
 
     @property
     def rate(self):
@@ -447,10 +462,12 @@ class Swift:
         if not self.headless:
             # A flag for our threads to monitor for when to quit
             self._run_thread = True
+            self._disconnected.clear()
             self.socket_thread, self.socket, self.server_thread, self.server, self._notebook_display_handle = start_servers(
                 self.outq,
                 self.inq,
                 self._servers_running,
+                self._disconnected,
                 browser=browser,
             )
 
@@ -1350,16 +1367,26 @@ class Swift:
         self.outq.put(msg)
 
         if expected:
-            try:
-                return self.inq.get(timeout=_REPLY_TIMEOUT)
-            except Empty:
-                raise TimeoutError(
-                    "Swift browser tab stopped responding (no reply to "
-                    f"'{code}' within {_REPLY_TIMEOUT}s) -- it may have been "
-                    "closed, crashed, or dropped into a different window/"
-                    "profile mid-drag. Call env.close() then env.launch() "
-                    "again to reconnect."
-                ) from None
+            # Poll in short slices rather than one blocking
+            # inq.get(timeout=_REPLY_TIMEOUT) -- so a disconnect
+            # SwiftSocket notices mid-wait (see SwiftRoute.py's
+            # expect_message()) ends this well before the full timeout,
+            # instead of _REPLY_TIMEOUT being the only possible bound.
+            start = time.time()
+            while True:
+                try:
+                    return self.inq.get(timeout=_DISCONNECT_POLL_INTERVAL)
+                except Empty:
+                    elapsed = time.time() - start
+                    if self._disconnected.is_set() or elapsed >= _REPLY_TIMEOUT:
+                        raise TimeoutError(
+                            "Swift browser tab stopped responding (no "
+                            f"reply to '{code}' after {elapsed:.1f}s) -- "
+                            "it may have been closed, crashed, or dropped "
+                            "into a different window/profile mid-drag. "
+                            "Call env.close() then env.launch() again to "
+                            "reconnect."
+                        ) from None
         else:
             return "0"
 

--- a/src/swift/SwiftRoute.py
+++ b/src/swift/SwiftRoute.py
@@ -6,7 +6,7 @@
 import swift as sw
 import websockets
 import asyncio
-from threading import Thread
+from threading import Thread, Event
 import webbrowser as wb
 import json
 import http.server
@@ -93,6 +93,7 @@ def start_servers(
     outq: Queue,
     inq: Queue,
     stop_servers,
+    disconnected: Event,
     open_tab: bool = True,
     browser: str | None = None,
 ):
@@ -117,6 +118,7 @@ def start_servers(
             outq,
             inq,
             stop_servers,
+            disconnected,
         ),
         daemon=True,
     )
@@ -214,10 +216,15 @@ def start_servers(
 
 
 class SwiftSocket:
-    def __init__(self, outq, inq, run):
+    def __init__(self, outq, inq, run, disconnected: Event):
         self.run = run
         self.outq = outq
         self.inq = inq
+        # Set the instant either race below (this loop's send side, or
+        # expect_message()'s reply side) notices the browser is gone --
+        # lets Swift._send_socket()'s blocked inq.get() bail out well
+        # before _REPLY_TIMEOUT, instead of it being the only bound.
+        self.disconnected = disconnected
         self.USERS = set()
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
@@ -288,6 +295,7 @@ class SwiftSocket:
                     # left to consume the result, so its value doesn't
                     # matter.
                     self.outq.put((False, ("__disconnect_sentinel__", None)))
+                    self.disconnected.set()
                     raise websockets.exceptions.ConnectionClosed(None, None)
                 closed_task.cancel()
                 message = producer_task.result()
@@ -306,9 +314,28 @@ class SwiftSocket:
         return
 
     async def expect_message(self, websocket, expected):
-        if expected:
-            recieved = await websocket.recv()
-            self.inq.put(recieved)
+        if not expected:
+            return
+
+        # Race against wait_closed() the same way serve()'s send side
+        # does above -- otherwise a disconnect while waiting for the
+        # browser's reply (the common case during an active step() loop,
+        # where the server spends nearly all its time right here) isn't
+        # noticed until Swift._send_socket()'s own _REPLY_TIMEOUT
+        # fallback gives up, up to _REPLY_TIMEOUT seconds later instead
+        # of near-instantly. See jhavl/swift#125.
+        recv_task = asyncio.ensure_future(websocket.recv())
+        closed_task = asyncio.ensure_future(websocket.wait_closed())
+        done, _ = await asyncio.wait(
+            [recv_task, closed_task], return_when=asyncio.FIRST_COMPLETED
+        )
+        if closed_task in done:
+            recv_task.cancel()
+            self.disconnected.set()
+            raise websockets.exceptions.ConnectionClosed(None, None)
+        closed_task.cancel()
+        recieved = recv_task.result()
+        self.inq.put(recieved)
 
     async def producer(self):
         # self.outq.get() is a genuine blocking call (a plain thread-safe

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,7 +13,7 @@ frontend has no way to detect on its own.
 import importlib
 import json
 import threading
-from queue import Queue
+from queue import Empty, Queue
 
 import numpy as np
 import pytest
@@ -498,7 +498,9 @@ def test_start_servers_socket_thread_actually_stops_on_close():
     outq, inq = Queue(), Queue()
     run_flag = [True]
     t = threading.Thread(
-        target=SwiftSocket, args=(outq, inq, lambda: run_flag[0]), daemon=True
+        target=SwiftSocket,
+        args=(outq, inq, lambda: run_flag[0], threading.Event()),
+        daemon=True,
     )
     t.start()
     port, instance = inq.get(timeout=5)
@@ -560,7 +562,7 @@ def test_swift_socket_notices_disconnect_even_while_idle():
 
     outq, inq = Queue(), Queue()
     t = threading.Thread(
-        target=SwiftSocket, args=(outq, inq, lambda: True), daemon=True
+        target=SwiftSocket, args=(outq, inq, lambda: True, threading.Event()), daemon=True
     )
     t.start()
     port, instance = inq.get(timeout=5)
@@ -588,6 +590,78 @@ def test_swift_socket_notices_disconnect_even_while_idle():
         "SwiftSocket.USERS was never cleaned up after an idle disconnect "
         "-- hold()'s disconnect-timeout polling would never fire"
     )
+
+
+def test_disconnect_while_waiting_for_a_reply_is_noticed_quickly():
+    # Regression test for the gap the idle-disconnect fix above didn't
+    # cover: serve()'s producer/wait_closed race only guards the *send*
+    # side, at the top of each loop iteration. expect_message()'s
+    # websocket.recv() -- where the server actually spends nearly all its
+    # time during an active step() loop, waiting for the browser's reply
+    # to the last message -- had no such race, so a disconnect right there
+    # (the common case, e.g. killing the tab mid-RRMC-loop) fell through
+    # entirely to _send_socket()'s own _REPLY_TIMEOUT fallback. Exercises
+    # a real client over a real websocket that vanishes without ever
+    # replying to a queued message, and asserts the resulting wait is a
+    # small fraction of _REPLY_TIMEOUT, not the full 15s.
+    import asyncio
+    import time
+
+    import websockets
+
+    from swift.SwiftRoute import SwiftSocket
+
+    outq, inq = Queue(), Queue()
+    disconnected = threading.Event()
+    t = threading.Thread(
+        target=SwiftSocket, args=(outq, inq, lambda: True, disconnected), daemon=True
+    )
+    t.start()
+    port, instance = inq.get(timeout=5)
+
+    connected = threading.Event()
+
+    def client_thread():
+        async def client():
+            async with websockets.connect(f"ws://localhost:{port}/") as ws:
+                await ws.send("Connected")
+                connected.set()
+                # Long enough for the server to have sent the queued
+                # message below and be sitting in expect_message()'s
+                # recv() -- then vanish without ever replying, simulating
+                # a tab killed mid-step().
+                await asyncio.sleep(0.3)
+
+        asyncio.run(client())
+
+    ct = threading.Thread(target=client_thread, daemon=True)
+    ct.start()
+    connected.wait(timeout=5)
+    inq.get(timeout=5)  # drain the handshake message
+
+    # Mirrors Swift._send_socket()'s own polling loop against this same
+    # outq/inq/disconnected, without needing a full Swift instance.
+    outq.put([True, ["shape_poses", []]])
+
+    start = time.time()
+    while True:
+        try:
+            inq.get(timeout=swift_module._DISCONNECT_POLL_INTERVAL)
+            break
+        except Empty:
+            if disconnected.is_set() or (time.time() - start) >= swift_module._REPLY_TIMEOUT:
+                break
+    elapsed = time.time() - start
+
+    assert disconnected.is_set(), "disconnect was never detected"
+    assert elapsed < 1.0, (
+        f"took {elapsed:.2f}s to notice the disconnect -- should be near-"
+        "instant, not bounded by _REPLY_TIMEOUT"
+    )
+
+    ct.join(timeout=2)
+    instance.stop()
+    t.join(timeout=3)
 
 
 def test_hold_duration_returns_even_while_still_connected(monkeypatch):


### PR DESCRIPTION
## Summary

The disconnect-detection fast path (`serve()`'s `producer`/`wait_closed` race) only guards the *send* side, at the top of each loop iteration -- built specifically for the idle `hold()` case, where nothing is ever queued so `producer()` alone would never notice a disconnect. `expect_message()`'s `websocket.recv()` -- where the server actually spends nearly all its time during an *active* `step()` loop, waiting for the browser's reply to the last message -- had no such race at all.

A disconnect right there (the common case -- killing the tab mid-`step()`-loop, e.g. an RRMC-style script) fell through entirely to `Swift._send_socket()`'s own `_REPLY_TIMEOUT` fallback: up to 15 seconds later, instead of near-instant.

Worse, tracing it further: even the *existing* idle-disconnect fast path never actually speeds up a concurrently-blocked `_send_socket()` call -- it only pushes a throwaway value onto `outq` (to stop `producer()`'s own background thread leaking), it never signals `inq`. So detecting the disconnect faster on the server's asyncio side alone wouldn't even have been visible to a Python-side caller already blocked in `inq.get(timeout=_REPLY_TIMEOUT)`.

## Fix (two parts)

- Race `expect_message()`'s `recv()` against `wait_closed()` too, mirroring the existing pattern at the top of `serve()`'s loop.
- Add a `threading.Event`, set by `SwiftSocket` the instant either race detects a disconnect, and change `_send_socket()` to poll in short (0.05s) slices against it instead of one blocking `inq.get(timeout=_REPLY_TIMEOUT)`.

Deliberately **not** a sentinel value pushed onto `inq` itself: `inq` persists across a `close()`/`launch()` reconnect (`Swift.__init__` creates it once; `launch()` never recreates it), so a disconnect detected while nothing is actually waiting on `inq` (e.g. mid-`hold()`) would otherwise leave a stale value sitting there to be wrongly consumed by the *next* session's handshake.

Also reworded the `TimeoutError` message to report actual elapsed time rather than a fixed `_REPLY_TIMEOUT` figure, since it can now legitimately fire well before that.

## Test plan

- [x] New test `test_disconnect_while_waiting_for_a_reply_is_noticed_quickly`: real client over a real websocket that vanishes mid-reply-wait, asserts the resulting wait is well under 1s (not bounded by `_REPLY_TIMEOUT`)
- [x] Confirmed the new test actually catches the regression: reverted just `expect_message()`'s race (keeping the rest of the plumbing) and re-ran -- fails at ~15s, disconnect never detected, as expected
- [x] Full suite passes: 93 passed, 8 deselected (one pre-existing, unrelated `spatialgeometry` Polyline gap from a stale local install, not this change)
- [x] Updated the two existing tests that construct `SwiftSocket` directly (`test_start_servers_socket_thread_actually_stops_on_close`, `test_swift_socket_notices_disconnect_even_while_idle`) for the new required `disconnected` param
