### PR TITLE
feat: Label(compact=True) for tight spacing without a shared CSS change

### DIFF
--- a/src/swift/SwiftElement.py
+++ b/src/swift/SwiftElement.py
@@ -203,13 +203,22 @@ class Label(SwiftElement):
 
     :param desc: the value of the label, optional
     :type desc: str
+    :param compact: use a tighter margin/font-size than the default
+        (sized for an occasional standalone heading) -- for several
+        Labels stacked close together, e.g. a multi-line live readout,
+        rather than a one-off title. Purely a display style, applied as
+        an inline override in the browser -- doesn't affect any other
+        Label instance, and the class-wide default is unchanged.
+        Optional, defaults to False.
+    :type compact: bool
     """
 
-    def __init__(self, desc=''):
+    def __init__(self, desc='', compact=False):
         super(Label, self).__init__()
 
         self._element = 'label'
         self.desc = desc
+        self.compact = compact
 
     @property
     def desc(self):
@@ -225,7 +234,8 @@ class Label(SwiftElement):
             'element': self._element,
             'id': self._id,
             'builtin': self.builtin,
-            'desc': self.desc
+            'desc': self.desc,
+            'compact': self.compact,
         }
 
     def update(self, _):

--- a/src/swift/public/js/ui.js
+++ b/src/swift/public/js/ui.js
@@ -114,6 +114,20 @@ export class Label {
     this.label = document.getElementById(`label${data.id}`);
     this.changed = false;
     this.data = 0;
+
+    if (data.compact) {
+      // .label-div's default margin/font-size (index.css) is sized for
+      // an occasional standalone heading, not several Labels stacked
+      // close together -- an inline override here (opt-in, per-instance)
+      // avoids touching that shared class and affecting every other
+      // Label, past or future, that wants the current spacious look.
+      const div = this.label.parentElement;
+      div.style.marginTop = "0.15cm";
+      div.style.marginBottom = "0.15cm";
+      this.label.style.fontSize = "13px";
+      this.label.style.fontWeight = "normal";
+    }
+
     this.update(data);
   }
 

--- a/tests/test_swift_element.py
+++ b/tests/test_swift_element.py
@@ -49,7 +49,25 @@ def test_button_to_dict():
 def test_label_to_dict():
     lab = Label(desc="hello")
     lab._id = 1
-    assert lab.to_dict() == {"element": "label", "id": 1, "builtin": False, "desc": "hello"}
+    assert lab.to_dict() == {
+        "element": "label",
+        "id": 1,
+        "builtin": False,
+        "desc": "hello",
+        "compact": False,
+    }
+
+
+def test_label_compact_to_dict():
+    lab = Label(desc="hello", compact=True)
+    lab._id = 1
+    assert lab.to_dict() == {
+        "element": "label",
+        "id": 1,
+        "builtin": False,
+        "desc": "hello",
+        "compact": True,
+    }
 
 
 def test_select_to_dict_and_update():


### PR DESCRIPTION
## Summary

`.label-div`'s default margin (`1cm` top, `0.5cm` bottom) and font-size (`1.3em`, bold) are sized for an occasional standalone heading, not several Labels stacked close together -- e.g. a multi-line live readout next to a slider panel, where the current spacing looks disproportionately spacious and pushes other elements off-screen (found while building a Swift teach() panel for roboticstoolbox-python -- see companion RTB PR).

No existing example in this repo uses `Label` at all, so nothing currently depends on today's spacing -- but editing the shared `.label-div` CSS class directly would still silently change the look for any future/external caller that *does* want the current spacious heading style.

## Fix

`Label(desc='', compact=False)` -- `compact=True` applies a tighter margin/font-size as an inline style override in the JS constructor. Default `False` leaves the shared CSS class, and every other `Label` instance, completely untouched.

## Test plan

- [x] `tests/test_swift_element.py`: new `test_label_compact_to_dict`, existing `test_label_to_dict` updated for the new `compact` field
- [x] Full suite passes: 94 passed, 9 deselected (one pre-existing, unrelated `spatialgeometry` Polyline gap from a stale local install, not this change)
- [x] Manually verified in a real browser: 6 stacked compact Labels no longer push joint sliders off-screen
