### PR TITLE
fix: run() lets a disconnect-during-step() crash out as a raw traceback

### DIFF
--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -1108,7 +1108,19 @@ class Swift:
 
         try:
             while duration is None or (self.sim_time - start_time) < duration:
-                self.step(dt)
+                try:
+                    self.step(dt)
+                except TimeoutError:
+                    # A disconnect noticed *during* step() (SwiftRoute.py's
+                    # expect_message()/producer racing wait_closed()) raises
+                    # here directly, rather than only ever surfacing via
+                    # the _check_disconnected() poll below -- without this,
+                    # it would propagate straight out of run() as a raw
+                    # traceback instead of the same graceful message/return
+                    # every other disconnect path already gets.
+                    print("\nSwift browser tab closed.")
+                    self.close()
+                    return
                 time.sleep(dt)
                 disconnected_since, expired = self._check_disconnected(disconnected_since, timeout)
                 if expired:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -725,6 +725,29 @@ def test_run_exits_quietly_on_keyboard_interrupt(monkeypatch):
     assert closed == [True]
 
 
+def test_run_exits_quietly_on_disconnect_during_step(capsys):
+    # A disconnect noticed *during* step() (SwiftRoute.py's
+    # expect_message()/producer racing wait_closed()) raises TimeoutError
+    # directly out of step(), rather than only ever surfacing via
+    # _check_disconnected()'s poll between steps -- run() must catch this
+    # the same way it already handles that poll-detected case (print,
+    # close(), return), not let it propagate as a raw traceback.
+    env = make_env()
+    env.headless = True
+
+    def step_raises(dt=0.05, render=True):
+        raise TimeoutError("Swift browser tab stopped responding")
+
+    env.step = step_raises
+    closed = []
+    env.close = lambda *a, **kw: closed.append(True)
+
+    env.run()  # must return normally, not raise
+
+    assert closed == [True]
+    assert "Swift browser tab closed." in capsys.readouterr().out
+
+
 def test_hold_exits_quietly_on_keyboard_interrupt(monkeypatch):
     env = make_env()
     env.headless = True


### PR DESCRIPTION
## Summary

A disconnect noticed *during* `step()` (`SwiftRoute.py`'s `expect_message()`/producer racing `wait_closed()`, #130) raises `TimeoutError` directly out of `step()` -- `run()`'s own loop only ever expected a disconnect to surface via `_check_disconnected()`'s poll *between* steps, so this propagated straight out of `run()` as an uncaught exception instead of the same graceful `"Swift browser tab closed."` message/return every other disconnect path already gets.

Not a hypothetical -- closing the browser tab mid-session reliably hits this, every time, now that #130 made disconnect detection fast enough (milliseconds, not 15s) to land mid-step almost always rather than rarely. Found while building an interactive `robot.teach(backend="swift")` panel for roboticstoolbox-python (built on `run()`) -- see companion RTB work.

## Fix

Catch `TimeoutError` around the loop's `step()` call in `run()`, same as the existing `expired` branch: print `"Swift browser tab closed."`, `close()`, return -- instead of letting it propagate.

## Test plan

- [x] New test `test_run_exits_quietly_on_disconnect_during_step`: mocks `step()` to raise `TimeoutError`, asserts `run()` returns normally (not raises) and prints the graceful message
- [x] Confirmed the test catches the regression: reverted just the `Swift.py` fix (keeping the test) and re-ran -- fails with the raw `TimeoutError` propagating, as expected
- [x] Full suite passes: 94 passed, 9 deselected (one pre-existing, unrelated `spatialgeometry` Polyline gap from a stale local install, not this change)
