### PR TITLE
feat(elements): make Slider's cb argument optional

### DIFF
--- a/examples/box_sliders.py
+++ b/examples/box_sliders.py
@@ -27,9 +27,9 @@ def box_pose(t, values):
 
 env.add_shape(box, callback=box_pose)
 
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, desc="Box Z", unit="m"), name="z")
+env.add_ui(Slider(min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box X", unit="m"), name="x")
+env.add_ui(Slider(min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box Y", unit="m"), name="y")
+env.add_ui(Slider(min=0.0, max=0.6, step=0.01, value=0.0, desc="Box Z", unit="m"), name="z")
 
 while True:
     env.step(0.05)

--- a/examples/panda_ik_sliders.py
+++ b/examples/panda_ik_sliders.py
@@ -53,9 +53,9 @@ def track_target(t, values):
 
 handle.callback = track_target
 
-env.add_ui(Slider(lambda v: None, min=0.2, max=0.7, step=0.01, value=X0, desc="Target X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.4, max=0.4, step=0.01, value=Y0, desc="Target Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, desc="Target Z", unit="m"), name="z")
+env.add_ui(Slider(min=0.2, max=0.7, step=0.01, value=X0, desc="Target X", unit="m"), name="x")
+env.add_ui(Slider(min=-0.4, max=0.4, step=0.01, value=Y0, desc="Target Y", unit="m"), name="y")
+env.add_ui(Slider(min=0.05, max=0.6, step=0.01, value=Z0, desc="Target Z", unit="m"), name="z")
 
 while True:
     env.step(dt)

--- a/examples/two_link_arm.py
+++ b/examples/two_link_arm.py
@@ -47,8 +47,8 @@ handle = env.add_assembly(
     callback=lambda t, values: [values["q1"], values["q2"]],
 )
 
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 1", unit="rad"), name="q1")
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 2", unit="rad"), name="q2")
+env.add_ui(Slider(min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 1", unit="rad"), name="q1")
+env.add_ui(Slider(min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 2", unit="rad"), name="q2")
 
 while True:
     env.step(0.05)

--- a/src/swift/SwiftElement.py
+++ b/src/swift/SwiftElement.py
@@ -68,7 +68,10 @@ class Slider(SwiftElement):
 
     :param cb: A callback function which is executed when the value of the
         slider changes. The callback should accept one argument which
-        represents the new value of the slider
+        represents the new value of the slider. Optional -- if not given,
+        the slider has no per-element callback, which is the common case
+        for a named slider read via ``env.values`` in a shape/assembly
+        callback instead.
     :type cb: function
     :param min: the minimum value of the slider, optional
     :type min: float
@@ -92,11 +95,11 @@ class Slider(SwiftElement):
 
     """
 
-    def __init__(self, cb, min=0, max=100, step=1, value=0, desc='', unit='', precision=3):
+    def __init__(self, cb=None, min=0, max=100, step=1, value=0, desc='', unit='', precision=3):
         super(Slider, self).__init__()
 
         self._element = 'slider'
-        self.cb = cb
+        self.cb = cb if cb is not None else lambda x: None
         self.min = min
         self.max = max
         self.step = step

--- a/tests/test_swift_element.py
+++ b/tests/test_swift_element.py
@@ -40,6 +40,12 @@ def test_slider_precision_defaults_to_3_and_is_settable():
     assert s2.to_dict()["precision"] == 1
 
 
+def test_slider_cb_is_optional():
+    s = Slider(min=0, max=10, value=3, desc="d")
+    assert s.to_dict()["value"] == 3.0
+    s.cb(3)  # default no-op cb must be callable, not None
+
+
 def test_button_to_dict():
     b = Button(lambda v: None, desc="Click Me")
     b._id = 0


### PR DESCRIPTION
## Summary
- `Slider(cb, ...)` required a callback positionally, forcing every named slider used with the `env.values`/`handle.callback` idiom (the common case — see `examples/box_sliders.py`, `panda_ik_sliders.py`, `two_link_arm.py`) to pass a throwaway `lambda v: None`
- `cb` now defaults to `None` and falls back to a no-op internally, so it can be omitted entirely or passed as a keyword — `Swift.process_events()`'s unconditional `self.elements[event].cb(...)` call stays safe either way
- Cleaned up the now-unnecessary dummy lambda in the three examples that only ever used the named-slider pattern

## Test plan
- [x] `pytest tests/test_swift_element.py tests/test_assembly_handle.py` — added `test_slider_cb_is_optional`, all existing tests (which still pass an explicit `cb`) untouched
- [x] Full `pytest` — no regressions (one pre-existing, unrelated failure: `test_add_path_sends_points_radius_and_linewidth`, caused by the installed `spatialgeometry` PyPI release lagging behind an unreleased `Polyline` rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)