### PR TITLE
feat(elements): rename desc -> label on all UI elements, with deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ def box_pose(t, values):
 
 env.add_shape(box, callback=box_pose)
 
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, desc="Box Z", unit="m"), name="z")
+env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, label="Box X", unit="m"), name="x")
+env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, label="Box Y", unit="m"), name="y")
+env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, label="Box Z", unit="m"), name="z")
 
 while True:
     env.step(0.05)
@@ -136,8 +136,8 @@ handle = env.add_assembly(
     callback=lambda t, values: [values["q1"], values["q2"]],
 )
 
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 1", unit="rad"), name="q1")
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 2", unit="rad"), name="q2")
+env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, label="Joint 1", unit="rad"), name="q1")
+env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, label="Joint 2", unit="rad"), name="q2")
 
 while True:
     env.step(0.05)
@@ -243,9 +243,9 @@ def track_target(t, values):
 
 handle.callback = track_target
 
-env.add_ui(Slider(lambda v: None, min=0.2, max=0.7, step=0.01, value=X0, desc="Target X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.4, max=0.4, step=0.01, value=Y0, desc="Target Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, desc="Target Z", unit="m"), name="z")
+env.add_ui(Slider(lambda v: None, min=0.2, max=0.7, step=0.01, value=X0, label="Target X", unit="m"), name="x")
+env.add_ui(Slider(lambda v: None, min=-0.4, max=0.4, step=0.01, value=Y0, label="Target Y", unit="m"), name="y")
+env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, label="Target Z", unit="m"), name="z")
 
 while True:
     env.step(dt)

--- a/examples/box_sliders.py
+++ b/examples/box_sliders.py
@@ -27,9 +27,9 @@ def box_pose(t, values):
 
 env.add_shape(box, callback=box_pose)
 
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, desc="Box Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, desc="Box Z", unit="m"), name="z")
+env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, label="Box X", unit="m"), name="x")
+env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, label="Box Y", unit="m"), name="y")
+env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, label="Box Z", unit="m"), name="z")
 
 while True:
     env.step(0.05)

--- a/examples/panda_ik_sliders.py
+++ b/examples/panda_ik_sliders.py
@@ -53,9 +53,9 @@ def track_target(t, values):
 
 handle.callback = track_target
 
-env.add_ui(Slider(lambda v: None, min=0.2, max=0.7, step=0.01, value=X0, desc="Target X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.4, max=0.4, step=0.01, value=Y0, desc="Target Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, desc="Target Z", unit="m"), name="z")
+env.add_ui(Slider(lambda v: None, min=0.2, max=0.7, step=0.01, value=X0, label="Target X", unit="m"), name="x")
+env.add_ui(Slider(lambda v: None, min=-0.4, max=0.4, step=0.01, value=Y0, label="Target Y", unit="m"), name="y")
+env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, label="Target Z", unit="m"), name="z")
 
 while True:
     env.step(dt)

--- a/examples/two_link_arm.py
+++ b/examples/two_link_arm.py
@@ -47,8 +47,8 @@ handle = env.add_assembly(
     callback=lambda t, values: [values["q1"], values["q2"]],
 )
 
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 1", unit="rad"), name="q1")
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, desc="Joint 2", unit="rad"), name="q2")
+env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, label="Joint 1", unit="rad"), name="q1")
+env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, label="Joint 2", unit="rad"), name="q2")
 
 while True:
     env.step(0.05)

--- a/src/swift/Swift.py
+++ b/src/swift/Swift.py
@@ -1406,7 +1406,7 @@ class Swift:
         # method (via process_events -> cb) and flips it back to False,
         # which is what breaks the outer loop.
         self._paused = not self._paused
-        self._pause_button.desc = "▶" if self._paused else "||"
+        self._pause_button.label = "▶" if self._paused else "||"
         # The loop below bypasses the normal step()/_step_elements() path
         # entirely (it only polls shape_poses directly), so the icon
         # change above would otherwise sit queued and unsent for as long
@@ -1422,7 +1422,7 @@ class Swift:
         self.realtime_speed = _REALTIME_SPEEDS[int(index)]
 
     def _add_controls(self):
-        self._pause_button = Button(self._pause_control, desc="||")
+        self._pause_button = Button(self._pause_control, label="||")
         self._pause_button.builtin = True
         self.add_ui(self._pause_button)
 
@@ -1435,7 +1435,7 @@ class Swift:
         except ValueError:
             speed_index = 0
         speed_select = Select(
-            self._time_control, desc="Speed", options=_REALTIME_SPEED_LABELS, value=speed_index
+            self._time_control, label="Speed", options=_REALTIME_SPEED_LABELS, value=speed_index
         )
         speed_select.builtin = True
         self.add_ui(speed_select)

--- a/src/swift/SwiftElement.py
+++ b/src/swift/SwiftElement.py
@@ -1,4 +1,5 @@
 
+import warnings
 from abc import ABC, abstractmethod
 from functools import wraps
 
@@ -76,7 +77,9 @@ class Slider(SwiftElement):
     :type max: float
     :param step: the step size of the slider, optional
     :type step: float
-    :param desc: add a description of the slider, optional
+    :param label: caption shown next to the slider, optional
+    :type label: str
+    :param desc: deprecated alias for ``label``
     :type desc: str
     :param unit: add a unit to the slider value, optional
     :type unit: str
@@ -92,8 +95,16 @@ class Slider(SwiftElement):
 
     """
 
-    def __init__(self, cb, min=0, max=100, step=1, value=0, desc='', unit='', precision=3):
+    def __init__(self, cb, min=0, max=100, step=1, value=0, label='', unit='', precision=3, desc=None):
         super(Slider, self).__init__()
+
+        if desc is not None:
+            warnings.warn(
+                "Slider(desc=...) is deprecated, use Slider(label=...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            label = desc
 
         self._element = 'slider'
         self.cb = cb
@@ -101,7 +112,7 @@ class Slider(SwiftElement):
         self.max = max
         self.step = step
         self.value = value
-        self.desc = desc
+        self.label = label
         self.unit = unit
         self.precision = precision
 
@@ -152,13 +163,31 @@ class Slider(SwiftElement):
         self._notify_value_changed()
 
     @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    @SwiftElement._update
+    def label(self, value):
+        self._label = value
+
+    @property
     def desc(self):
-        return self._desc
+        warnings.warn(
+            "Slider.desc is deprecated, use Slider.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._label
 
     @desc.setter
-    @SwiftElement._update
     def desc(self, value):
-        self._desc = value
+        warnings.warn(
+            "Slider.desc is deprecated, use Slider.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.label = value
 
     @property
     def unit(self):
@@ -187,7 +216,7 @@ class Slider(SwiftElement):
             'max': self.max,
             'step': self.step,
             'value': self.value,
-            'desc': self.desc,
+            'label': self.label,
             'unit': self.unit,
             'precision': self.precision,
         }
@@ -201,31 +230,59 @@ class Label(SwiftElement):
     """
     Create a Label html element
 
-    :param desc: the value of the label, optional
+    :param label: the text of the label, optional
+    :type label: str
+    :param desc: deprecated alias for ``label``
     :type desc: str
     """
 
-    def __init__(self, desc=''):
+    def __init__(self, label='', desc=None):
         super(Label, self).__init__()
 
+        if desc is not None:
+            warnings.warn(
+                "Label(desc=...) is deprecated, use Label(label=...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            label = desc
+
         self._element = 'label'
-        self.desc = desc
+        self.label = label
+
+    @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    @SwiftElement._update
+    def label(self, value):
+        self._label = value
 
     @property
     def desc(self):
-        return self._desc
+        warnings.warn(
+            "Label.desc is deprecated, use Label.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._label
 
     @desc.setter
-    @SwiftElement._update
     def desc(self, value):
-        self._desc = value
+        warnings.warn(
+            "Label.desc is deprecated, use Label.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.label = value
 
     def to_dict(self):
         return {
             'element': self._element,
             'id': self._id,
             'builtin': self.builtin,
-            'desc': self.desc
+            'label': self.label
         }
 
     def update(self, _):
@@ -240,16 +297,26 @@ class Button(SwiftElement):
         clicked. The callback should accept one argument which
         can be disregarded
     :type cb: function
-    :param desc: text written on the button, optional
+    :param label: text written on the button, optional
+    :type label: str
+    :param desc: deprecated alias for ``label``
     :type desc: str
     """
 
-    def __init__(self, cb, desc=''):
+    def __init__(self, cb, label='', desc=None):
         super(Button, self).__init__()
+
+        if desc is not None:
+            warnings.warn(
+                "Button(desc=...) is deprecated, use Button(label=...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            label = desc
 
         self._element = 'button'
         self.cb = cb
-        self.desc = desc
+        self.label = label
 
     @property
     def cb(self):
@@ -261,20 +328,38 @@ class Button(SwiftElement):
         self._cb = value
 
     @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    @SwiftElement._update
+    def label(self, value):
+        self._label = value
+
+    @property
     def desc(self):
-        return self._desc
+        warnings.warn(
+            "Button.desc is deprecated, use Button.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._label
 
     @desc.setter
-    @SwiftElement._update
     def desc(self, value):
-        self._desc = value
+        warnings.warn(
+            "Button.desc is deprecated, use Button.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.label = value
 
     def to_dict(self):
         return {
             'element': self._element,
             'id': self._id,
             'builtin': self.builtin,
-            'desc': self.desc
+            'label': self.label
         }
 
     def update(self, _):
@@ -289,7 +374,9 @@ class Select(SwiftElement):
         box changes. The callback should accept one argument which
         represents the index of the new value
     :type cb: function
-    :param desc: add a description of the select box, optional
+    :param label: caption shown next to the select box, optional
+    :type label: str
+    :param desc: deprecated alias for ``label``
     :type desc: str
     :param options: represent the options inside the select box, optional
     :type options: List of str
@@ -298,12 +385,20 @@ class Select(SwiftElement):
     :type value: int
     """
 
-    def __init__(self, cb, desc='', options=[], value=0):
+    def __init__(self, cb, label='', options=[], value=0, desc=None):
         super(Select, self).__init__()
+
+        if desc is not None:
+            warnings.warn(
+                "Select(desc=...) is deprecated, use Select(label=...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            label = desc
 
         self._element = 'select'
         self.cb = cb
-        self.desc = desc
+        self.label = label
         self.options = options
         self.value = value
 
@@ -317,13 +412,31 @@ class Select(SwiftElement):
         self._cb = value
 
     @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    @SwiftElement._update
+    def label(self, value):
+        self._label = value
+
+    @property
     def desc(self):
-        return self._desc
+        warnings.warn(
+            "Select.desc is deprecated, use Select.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._label
 
     @desc.setter
-    @SwiftElement._update
     def desc(self, value):
-        self._desc = value
+        warnings.warn(
+            "Select.desc is deprecated, use Select.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.label = value
 
     @property
     def options(self):
@@ -349,7 +462,7 @@ class Select(SwiftElement):
             'element': self._element,
             'id': self._id,
             'builtin': self.builtin,
-            'desc': self.desc,
+            'label': self.label,
             'options': self.options,
             'value': self.value
         }
@@ -367,7 +480,9 @@ class Checkbox(SwiftElement):
         The callback should accept one argument which represents a List of
         bool representing the checked state of each box
     :type cb: function
-    :param desc: add a description of the checkboxes, optional
+    :param label: caption shown next to the checkboxes, optional
+    :type label: str
+    :param desc: deprecated alias for ``label``
     :type desc: str
     :param options: represents the checkboxes, optional
     :type options: List of str
@@ -375,12 +490,20 @@ class Checkbox(SwiftElement):
     :type checked: List of bool
     """
 
-    def __init__(self, cb, desc='', options=[], checked=[]):
+    def __init__(self, cb, label='', options=[], checked=[], desc=None):
         super(Checkbox, self).__init__()
+
+        if desc is not None:
+            warnings.warn(
+                "Checkbox(desc=...) is deprecated, use Checkbox(label=...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            label = desc
 
         self._element = 'checkbox'
         self.cb = cb
-        self.desc = desc
+        self.label = label
         self.options = options
         self.checked = checked
 
@@ -394,13 +517,31 @@ class Checkbox(SwiftElement):
         self._cb = value
 
     @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    @SwiftElement._update
+    def label(self, value):
+        self._label = value
+
+    @property
     def desc(self):
-        return self._desc
+        warnings.warn(
+            "Checkbox.desc is deprecated, use Checkbox.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._label
 
     @desc.setter
-    @SwiftElement._update
     def desc(self, value):
-        self._desc = value
+        warnings.warn(
+            "Checkbox.desc is deprecated, use Checkbox.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.label = value
 
     @property
     def options(self):
@@ -431,7 +572,7 @@ class Checkbox(SwiftElement):
             'element': self._element,
             'id': self._id,
             'builtin': self.builtin,
-            'desc': self.desc,
+            'label': self.label,
             'options': self.options,
             'checked': self.checked
         }
@@ -448,7 +589,9 @@ class Radio(SwiftElement):
         The callback should accept one argument which represents a index
         corresponding to the checked radio button
     :type cb: function
-    :param desc: add a description of the radio buttons, optional
+    :param label: caption shown next to the radio buttons, optional
+    :type label: str
+    :param desc: deprecated alias for ``label``
     :type desc: str
     :param options: represents the radio buttons, optional
     :type options: List of str
@@ -456,12 +599,20 @@ class Radio(SwiftElement):
     :type checked: int
     """
 
-    def __init__(self, cb, desc='', options=[], checked=[]):
+    def __init__(self, cb, label='', options=[], checked=[], desc=None):
         super(Radio, self).__init__()
+
+        if desc is not None:
+            warnings.warn(
+                "Radio(desc=...) is deprecated, use Radio(label=...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            label = desc
 
         self._element = 'radio'
         self.cb = cb
-        self.desc = desc
+        self.label = label
         self.options = options
         self.checked = checked
 
@@ -475,13 +626,31 @@ class Radio(SwiftElement):
         self._cb = value
 
     @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    @SwiftElement._update
+    def label(self, value):
+        self._label = value
+
+    @property
     def desc(self):
-        return self._desc
+        warnings.warn(
+            "Radio.desc is deprecated, use Radio.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._label
 
     @desc.setter
-    @SwiftElement._update
     def desc(self, value):
-        self._desc = value
+        warnings.warn(
+            "Radio.desc is deprecated, use Radio.label instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.label = value
 
     @property
     def options(self):
@@ -511,7 +680,7 @@ class Radio(SwiftElement):
             'element': self._element,
             'id': self._id,
             'builtin': self.builtin,
-            'desc': self.desc,
+            'label': self.label,
             'options': self.options,
             'checked': self.checked
         }

--- a/src/swift/public/js/ui.js
+++ b/src/swift/public/js/ui.js
@@ -24,7 +24,7 @@ export class Slider {
   constructor(data) {
     insert(`
       <div class="slider-div" id="slider-div${data.id}">
-        <p class="slider-p" id="desc${data.id}"></p>
+        <p class="slider-p" id="label${data.id}"></p>
         <input type="range" value="0" step="1" min="0" max="100" class="slider" id="slider${data.id}">
         <div class="slider-val-div" id="slider-val-div${data.id}">
           <p class="slider-vals slider-min" id="min${data.id}">0</p>
@@ -39,7 +39,7 @@ export class Slider {
     this.value = document.getElementById(`value${data.id}`);
     this.min = document.getElementById(`min${data.id}`);
     this.max = document.getElementById(`max${data.id}`);
-    this.desc = document.getElementById(`desc${data.id}`);
+    this.label = document.getElementById(`label${data.id}`);
 
     this.onInput = () => {
       // toFixed(), not toPrecision() -- this.precision is decimal places
@@ -72,7 +72,7 @@ export class Slider {
     // precision=, since these were never touched by that fix at all.
     this.min.innerHTML = Number(data.min).toFixed(data.precision);
     this.max.innerHTML = Number(data.max).toFixed(data.precision);
-    this.desc.innerHTML = data.desc;
+    this.label.innerHTML = data.label;
     this.onInput();
   }
 }
@@ -102,7 +102,7 @@ export class Button {
   }
 
   update(data) {
-    this.button.innerHTML = data.desc;
+    this.button.innerHTML = data.label;
   }
 }
 
@@ -118,7 +118,7 @@ export class Label {
   }
 
   update(data) {
-    this.label.innerHTML = data.desc;
+    this.label.innerHTML = data.label;
   }
 }
 
@@ -154,7 +154,7 @@ export class Select {
   }
 
   update(data) {
-    if (this.label) this.label.innerHTML = data.desc;
+    if (this.label) this.label.innerHTML = data.label;
     this.select.innerHTML = data.options
       .map((opt, i) => `<option value="${i}">${opt}</option>`)
       .join("");
@@ -186,7 +186,7 @@ export class Checkbox {
   }
 
   update(data) {
-    this.label.innerHTML = data.desc;
+    this.label.innerHTML = data.label;
     this.checkbox.innerHTML = data.options
       .map((opt, i) => {
         const checked = data.checked[i] ? "checked" : "";
@@ -225,7 +225,7 @@ export class Radio {
   }
 
   update(data) {
-    this.label.innerHTML = data.desc;
+    this.label.innerHTML = data.label;
     this.radio.innerHTML = data.options
       .map((opt, i) => {
         const checked = data.checked === i ? "checked" : "";

--- a/src/swift/public/js/ui.test.js
+++ b/src/swift/public/js/ui.test.js
@@ -39,7 +39,7 @@ test("Slider reports a numeric .data, not the DOM's stringified value", (t) => {
   // event.py callback even if no slider was ever touched.
   const slider = new Slider({
     id: 0,
-    desc: "Box X",
+    label: "Box X",
     unit: "m",
     precision: 2,
     value: 0.3,

--- a/tests/test_assembly_handle.py
+++ b/tests/test_assembly_handle.py
@@ -213,7 +213,7 @@ def test_show_lists_user_elements_alongside_builtin_ones(capsys):
 
     env = make_env()
     env._add_controls()
-    env.add_ui(Slider(lambda v: None, desc="speed"), name="speed")
+    env.add_ui(Slider(lambda v: None, label="speed"), name="speed")
 
     env.show()
     out = capsys.readouterr().out

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -245,7 +245,7 @@ def test_add_controls_sends_two_builtin_elements():
     _, pause_data = browser.received[0]
     assert pause_data["element"] == "button"
     assert pause_data["builtin"] is True
-    assert pause_data["desc"] == "||"
+    assert pause_data["label"] == "||"
 
     _, speed_data = browser.received[1]
     assert speed_data["element"] == "select"
@@ -261,7 +261,7 @@ def test_pause_toggles_on_click_and_unblocks_on_second_click():
     env._add_controls()
 
     assert env._paused is False
-    assert env._pause_button.desc == "||"
+    assert env._pause_button.label == "||"
 
     # Simulate a second click arriving while the pause loop below is
     # polling, by scripting its next shape_poses reply to report element
@@ -273,7 +273,7 @@ def test_pause_toggles_on_click_and_unblocks_on_second_click():
     env._pause_control(None)  # the first click
 
     assert env._paused is False
-    assert env._pause_button.desc == "||"
+    assert env._pause_button.label == "||"
     browser.stop()
 
 

--- a/tests/test_swift_element.py
+++ b/tests/test_swift_element.py
@@ -5,11 +5,13 @@ are built against (see swift/public/js/ui.js) -- a change here without a
 matching browser-side change silently breaks the UI panel.
 """
 
+import pytest
+
 from swift.SwiftElement import Button, Checkbox, Label, Radio, Select, Slider
 
 
 def test_slider_to_dict():
-    s = Slider(lambda v: None, min=0, max=10, step=0.5, value=2.5, desc="d", unit="u")
+    s = Slider(lambda v: None, min=0, max=10, step=0.5, value=2.5, label="d", unit="u")
     s._id = 3
     assert s.to_dict() == {
         "element": "slider",
@@ -19,7 +21,7 @@ def test_slider_to_dict():
         "max": 10.0,
         "step": 0.5,
         "value": 2.5,
-        "desc": "d",
+        "label": "d",
         "unit": "u",
         "precision": 3,
     }
@@ -41,25 +43,25 @@ def test_slider_precision_defaults_to_3_and_is_settable():
 
 
 def test_button_to_dict():
-    b = Button(lambda v: None, desc="Click Me")
+    b = Button(lambda v: None, label="Click Me")
     b._id = 0
-    assert b.to_dict() == {"element": "button", "id": 0, "builtin": False, "desc": "Click Me"}
+    assert b.to_dict() == {"element": "button", "id": 0, "builtin": False, "label": "Click Me"}
 
 
 def test_label_to_dict():
-    lab = Label(desc="hello")
+    lab = Label(label="hello")
     lab._id = 1
-    assert lab.to_dict() == {"element": "label", "id": 1, "builtin": False, "desc": "hello"}
+    assert lab.to_dict() == {"element": "label", "id": 1, "builtin": False, "label": "hello"}
 
 
 def test_select_to_dict_and_update():
-    sel = Select(lambda v: None, desc="pick one", options=["a", "b", "c"], value=1)
+    sel = Select(lambda v: None, label="pick one", options=["a", "b", "c"], value=1)
     sel._id = 2
     assert sel.to_dict() == {
         "element": "select",
         "id": 2,
         "builtin": False,
-        "desc": "pick one",
+        "label": "pick one",
         "options": ["a", "b", "c"],
         "value": 1,
     }
@@ -68,13 +70,13 @@ def test_select_to_dict_and_update():
 
 
 def test_checkbox_to_dict_and_update():
-    cb = Checkbox(lambda v: None, desc="opts", options=["x", "y"], checked=[True, False])
+    cb = Checkbox(lambda v: None, label="opts", options=["x", "y"], checked=[True, False])
     cb._id = 4
     assert cb.to_dict() == {
         "element": "checkbox",
         "id": 4,
         "builtin": False,
-        "desc": "opts",
+        "label": "opts",
         "options": ["x", "y"],
         "checked": [True, False],
     }
@@ -88,13 +90,13 @@ def test_checkbox_checked_from_int_index():
 
 
 def test_radio_to_dict_and_update():
-    r = Radio(lambda v: None, desc="pick", options=["x", "y"], checked=0)
+    r = Radio(lambda v: None, label="pick", options=["x", "y"], checked=0)
     r._id = 5
     assert r.to_dict() == {
         "element": "radio",
         "id": 5,
         "builtin": False,
-        "desc": "pick",
+        "label": "pick",
         "options": ["x", "y"],
         "checked": [True, False],
     }
@@ -103,7 +105,7 @@ def test_radio_to_dict_and_update():
 
 
 def test_builtin_flag_defaults_false_and_is_settable():
-    b = Button(lambda v: None, desc="||")
+    b = Button(lambda v: None, label="||")
     assert b.builtin is False
     b.builtin = True
     assert b.to_dict()["builtin"] is True
@@ -117,3 +119,42 @@ def test_changed_flag_only_set_once_added_to_swift():
     s._added_to_swift = True
     s.value = 2
     assert s._changed is True
+
+
+@pytest.mark.parametrize(
+    "cls,kwargs",
+    [
+        (Slider, {"cb": lambda v: None}),
+        (Label, {}),
+        (Button, {"cb": lambda v: None}),
+        (Select, {"cb": lambda v: None}),
+        (Checkbox, {"cb": lambda v: None}),
+        (Radio, {"cb": lambda v: None}),
+    ],
+)
+def test_desc_constructor_kwarg_is_deprecated_but_still_works(cls, kwargs):
+    with pytest.deprecated_call():
+        el = cls(desc="legacy text", **kwargs)
+    assert el.label == "legacy text"
+
+
+@pytest.mark.parametrize(
+    "cls,kwargs",
+    [
+        (Slider, {"cb": lambda v: None}),
+        (Label, {}),
+        (Button, {"cb": lambda v: None}),
+        (Select, {"cb": lambda v: None}),
+        (Checkbox, {"cb": lambda v: None}),
+        (Radio, {"cb": lambda v: None}),
+    ],
+)
+def test_desc_property_is_deprecated_but_still_works(cls, kwargs):
+    el = cls(**kwargs)
+
+    with pytest.deprecated_call():
+        el.desc = "legacy text"
+    assert el.label == "legacy text"
+
+    with pytest.deprecated_call():
+        assert el.desc == "legacy text"


### PR DESCRIPTION
## Summary
- `desc` was a poor name for what's actually the caption/text shown on a Slider, Label, Button, Select, Checkbox, or Radio — `label` says what it is directly
- Renamed the constructor param and property across all six `SwiftElement` subclasses, plus the wire-protocol dict key `ui.js` reads
- `desc` keeps working everywhere (constructor kwarg and property, get and set) via a deprecation shim that forwards to `label` and emits a `DeprecationWarning` — nothing is removed, existing user code (including RTB's) keeps running, just with a warning pointing at the new name
- Also renamed Slider's internal `desc` DOM id/JS field to `label`, matching how Button/Select/Checkbox/Radio/Label already name their own caption element — Slider was the only one still called `desc` client-side too
- Updated all in-repo examples, README, and tests to the new `label=` kwarg; added parametrized tests covering the deprecated `desc=` constructor kwarg and property on every element class

## Test plan
- [x] `pytest` — no regressions (one pre-existing, unrelated failure: `test_add_path_sends_points_radius_and_linewidth`, caused by the installed `spatialgeometry` PyPI release lagging behind an unreleased `Polyline` rename)
- [x] `node --test src/swift/public/js/*.test.js` — no regressions
- [ ] Manual check: run one of the slider examples, confirm captions still render correctly in the browser panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)