### PR TITLE
fix: revert ccapture.js 1.1.0 -> 2.0.0 dependabot bump

### DIFF
--- a/src/swift/public/package-lock.json
+++ b/src/swift/public/package-lock.json
@@ -6,14 +6,14 @@
     "": {
       "name": "swift-public-assets",
       "dependencies": {
-        "ccapture.js": "2.0.0",
+        "ccapture.js": "1.1.0",
         "three": "0.185.1"
       }
     },
     "node_modules/ccapture.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ccapture.js/-/ccapture.js-2.0.0.tgz",
-      "integrity": "sha512-6cKIIcK8TIX6uKffk6ItOwsmOnvp5Wx6YXKK6QYWUJFts2OTcLm66feEP6tOclosUE3MicjHz/cG4GbuUWgK2w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccapture.js/-/ccapture.js-1.1.0.tgz",
+      "integrity": "sha512-28kiHJzFsZ6b0OTfKpWpEwK2n/LTAgytK1uzB+413dzjHltdh2hP5Yg2qR0+9Xw3XoBMz5UkGCh8Ektr2rVlmw==",
       "license": "MIT"
     },
     "node_modules/three": {

--- a/src/swift/public/package.json
+++ b/src/swift/public/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "three": "0.185.1",
-    "ccapture.js": "2.0.0"
+    "ccapture.js": "1.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- `main`'s tip has a broken vendor build: Dependabot PR #127 bumped `ccapture.js` from `1.1.0` to `2.0.0` in `src/swift/public/package.json`/`package-lock.json`, and it was merged even though its own "Vendor assets check" CI failed.
- `ccapture.js@2.0.0` is a breaking rewrite -- its build output moved from `build/CCapture.all.min.js`/`CCapture.min.js` to `build/ccapture.umd.js`/`ccapture.umd.min.js`. `build-vendor.cjs` still copies the old filenames, so `npm run build:vendor` fails with `ENOENT` -- breaking every PR that touches `src/swift/public/**`, regardless of what that PR actually changes (hit this on #133 and #135, neither of which touch this dependency).
- This reverts `package.json`/`package-lock.json` back to `1.1.0`. The committed `js/vendor/` tree was never actually rebuilt against 2.0.0 (the build failed before it could produce anything), so it's already consistent with 1.1.0 -- verified locally: `npm ci && npm test && npm run build:vendor` all pass, and the rebuilt tree produces **no diff** against what's committed.
- Migrating to `ccapture.js` 2.0.0 properly (new build layout, ESM-first API, whatever call sites need updating) is real work and is being tracked separately as tech debt rather than attempted here.

## Test plan
- [x] `npm ci && npm test && npm run build:vendor` locally in `src/swift/public/` -- succeeds, `git diff -- js/vendor/` is empty