### PR TITLE
ci: build and deploy Sphinx docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,71 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, future]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deployment at a time; don't cancel an in-progress deploy
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build-time dependencies
+        run: pip install numpy setuptools wheel
+
+      - name: Install spatialgeometry from its own main branch
+        # main renamed Path -> Polyline (jhavl/spatialgeometry#42) but that
+        # hasn't been cut into a PyPI release yet -- swift-sim's own
+        # dependency floor (spatialgeometry>=1.4.0) has no matching
+        # release either, so a plain `pip install .[docs]` can't resolve
+        # at all. Same workaround as python-tests.yml.
+        run: pip install --force-reinstall --no-deps "git+https://github.com/jhavl/spatialgeometry.git@main"
+
+      - name: Install swift-sim and docs dependencies
+        run: pip install --no-build-isolation -e ".[docs]"
+
+      - name: Install system dependencies
+        # graphviz is required by sphinx.ext.inheritance_diagram
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
+      - name: Build docs
+        run: sphinx-build -b html -W docs/source docs/build/html
+
+      - name: Prepare Pages artifact
+        run: touch docs/build/html/.nojekyll
+
+      - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push'
+        with:
+          path: docs/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@
 
 Swift is a light-weight browser-based animation visualizer which provides:
 
-  * visualisation of mesh objects (Collada, STL, OBJ, glTF/GLB, PLY, VRML/WRL, and PCD files) and primitive shapes;
+  * visualisation of mesh objects (Collada, STL, OBJ, glTF/GLB, PLY, VRML/WRL, and PCD files) and primitive shapes such as cuboids, spheres, cylinders, ellipsoids, polylines and axes;
   * visualisation of multi-link robots created with the [Robotics Toolbox for Python](https://github.com/petercorke/robotics-toolbox-python);
   * interactive UI controls (sliders, buttons, and more) for driving a scene from the browser;
   * recording and saving a video of the simulation;
   * source code which can be read for learning and teaching;
 
-Built using Python and Javascript, Swift is cross-platform (Linux, MacOS, and Windows) while also leveraging the ubiquity and support of these languages.
+Built using Python and JavaScript (ES modules), Swift is cross-platform (Linux, MacOS, and Windows) while also leveraging the ubiquity and support of these languages.
 
 <p align="center">
  <img src=".github/figures/panda_follow_target.gif" alt="A Panda arm following a slider-controlled target box in Swift">

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Swift
 
+### Status & Project Health
 [![PyPI version](https://badge.fury.io/py/swift-sim.svg)](https://badge.fury.io/py/swift-sim)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/swift-sim)](https://img.shields.io/pypi/pyversions/swift-sim)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+### Ecosystem & Dependencies
 [![A Python Robotics Package](https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/master/.github/svg/py_collection.min.svg)](https://github.com/petercorke/robotics-toolbox-python)
 [![QUT Centre for Robotics Open Source](https://github.com/qcr/qcr.github.io/raw/master/misc/badge.svg)](https://qcr.github.io)
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Built using Python and JavaScript (ES modules), Swift is cross-platform (Linux, 
 </p>
 
 Swift provides robotics-specific functionality for rapid prototyping of algorithms, research, and education. 
-Through the [Robotics Toolbox for Python](https://github.com/petercorke/robotics-toolbox-python), Swift can visualise over 30 supplied robot models: well-known contemporary robots from Franka-Emika, Kinova, Universal Robotics, Rethink as well as classical robots such as the Puma 560 and the Stanford arm. Swift is under development and will support mobile robots in the future.
+Through the [Robotics Toolbox for Python](https://github.com/petercorke/robotics-toolbox-python), Swift can visualise over 150 supplied robot models: well-known contemporary robots from Franka-Emika, Kinova, Universal Robotics, Rethink as well as classical robots such as the Puma 560 and the Stanford arm. Swift is under development and will support mobile robots in the future.
 
 ## What's new in 2.0
 
-Swift's browser frontend has been rebuilt from scratch as modern, dependency-free ES modules (no bundler, no framework, current three.js) — see this release's changelog for the full list. For existing users:
+Swift's browser frontend has been rebuilt from scratch as modern, dependency-free ES modules (no bundler, no framework, current three.js) — see [CHANGELOG.md](./CHANGELOG.md) for the full list. For existing users:
 
   * a bottom-left playback panel with a pause/play button and a realtime-speed selector (Max/1x/0.5x/0.25x) — see [Playback controls](https://jhavl.github.io/swift/swift.html#playback-controls);
   * WebRTC support has been removed (`comms="rtc"`, the `vision` install extra) — it had no live-camera use case and wasn't providing anything a plain WebSocket doesn't already handle for the normal desktop/browser setup this simulator targets;
@@ -49,13 +49,11 @@ Swift's browser frontend has been rebuilt from scratch as modern, dependency-fre
 These build up from the simplest possible scene to a fully interactive one. All are in [`examples/`](./examples) and runnable as-is.
 More detailed documentation at [Introduction and tutorial](https://jhavl.github.io/swift/intro.html).
 
-
 ### Render a box, with sliders to move it
 
 Named sliders (`name=...`) push their current value into `env.values`; a per-step callback reads it from there and returns the box's new pose — no per-slider setter function, no manual pose assignment in the loop. The Z slider controls height above the floor (the box's bottom face, not its centre), so it's never possible to clip the box through the ground:
 
 ```python
-import time
 import spatialgeometry as sg
 from spatialmath import SE3
 from swift import Swift, Slider
@@ -74,13 +72,11 @@ def box_pose(t, values):
 
 env.add_shape(box, callback=box_pose)
 
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, label="Box X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.5, max=0.5, step=0.01, value=0.0, label="Box Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.0, max=0.6, step=0.01, value=0.0, label="Box Z", unit="m"), name="z")
+env.add_ui(Slider(min=-0.5, max=0.5, step=0.01, value=0.0, label="Box X", unit="m"), name="x")
+env.add_ui(Slider(min=-0.5, max=0.5, step=0.01, value=0.0, label="Box Y", unit="m"), name="y")
+env.add_ui(Slider(min=0.0, max=0.6, step=0.01, value=0.0, label="Box Z", unit="m"), name="z")
 
-while True:
-    env.step(0.05)
-    time.sleep(0.05)
+env.run(dt=0.05)  # run forever at 20 fps
 ```
 
 ### Panda arm follows a target, positioned by sliders
@@ -88,7 +84,6 @@ while True:
 The most complete example: a target box is positioned by three named sliders, and on every step the arm runs resolved-rate motion control (`rtb.p_servo`) towards wherever that box currently is — move a slider, the box moves, and the arm continuously chases it. Both the box's pose and the arm's `q` are computed by per-step callbacks reading from `env.values`, so the whole thing runs off a plain `env.step()` loop with no pose/`q` mutation inside it:
 
 ```python
-import time
 import numpy as np
 import roboticstoolbox as rtb
 import spatialgeometry as sg
@@ -131,13 +126,11 @@ def track_target(t, values):
 
 handle.callback = track_target
 
-env.add_ui(Slider(lambda v: None, min=0.2, max=0.7, step=0.01, value=X0, label="Target X", unit="m"), name="x")
-env.add_ui(Slider(lambda v: None, min=-0.4, max=0.4, step=0.01, value=Y0, label="Target Y", unit="m"), name="y")
-env.add_ui(Slider(lambda v: None, min=0.05, max=0.6, step=0.01, value=Z0, label="Target Z", unit="m"), name="z")
+env.add_ui(Slider(min=0.2, max=0.7, step=0.01, value=X0, label="Target X", unit="m"), name="x")
+env.add_ui(Slider(min=-0.4, max=0.4, step=0.01, value=Y0, label="Target Y", unit="m"), name="y")
+env.add_ui(Slider(min=0.05, max=0.6, step=0.01, value=Z0, label="Target Z", unit="m"), name="z")
 
-while True:
-    env.step(dt)
-    time.sleep(dt)
+env.run(dt=dt)  # run forever, calling track_target/target_pose each step
 ```
 
 ### Embed within a Jupyter Notebook
@@ -157,20 +150,16 @@ Swift is designed to be controlled through the [Robotics Toolbox for Python](htt
 pip install roboticstoolbox-python
 ```
 
-Otherwise, Swift can be install by
+Otherwise, Swift can be installed by
 
 ```shell script
 pip install swift-sim
 ```
 
-Available options are:
-
-- `nb` provides the ability for Swift to be embedded within a Jupyter Notebook
-
-Put the options in a comma-separated list like
+To include support for embedding within a Jupyter Notebook:
 
 ```shell script
-pip install swift-sim[optionlist]
+pip install swift-sim[nb]
 ```
 
 Swift requires Python 3.10 or later.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ### Status & Project Health
 [![PyPI version](https://badge.fury.io/py/swift-sim.svg)](https://badge.fury.io/py/swift-sim)
+[![Downloads](https://static.pepy.tech/badge/swift-sim/month)](https://pepy.tech/projects/swift-sim)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/swift-sim)](https://img.shields.io/pypi/pyversions/swift-sim)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Through the [Robotics Toolbox for Python](https://github.com/petercorke/robotics
 
 Swift's browser frontend has been rebuilt from scratch as modern, dependency-free ES modules (no bundler, no framework, current three.js) — see this release's changelog for the full list. For existing users:
 
-  * a bottom-left playback panel with a pause/play button and a realtime-speed selector (Max/1x/0.5x/0.25x) — see [Playback controls](#playback-controls) below;
+  * a bottom-left playback panel with a pause/play button and a realtime-speed selector (Max/1x/0.5x/0.25x) — see [Playback controls](https://jhavl.github.io/swift/swift.html#playback-controls);
   * WebRTC support has been removed (`comms="rtc"`, the `vision` install extra) — it had no live-camera use case and wasn't providing anything a plain WebSocket doesn't already handle for the normal desktop/browser setup this simulator targets;
   * `env.add()` is now four explicit methods — `add_shape()`, `add_ui()`, `add_assembly()`, `add_robot()` — one entry point per kind of thing, no type-checking required. `env.add()` still works and dispatches to these, kept for backward compatibility;
   * `add_robot()`/`add_assembly()` return an **`AssemblyHandle`** that owns that instance's live joint state (`handle.q`, `handle.qd`) — the `robot` model (or bare forward-kinematics function, for `add_assembly()`) stays plain and shareable, driven functionally (`panda.fkine(handle.q)`, `panda.jacobe(handle.q)`). Setting `robot.q`/`robot.qd` directly still works but is deprecated;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/swift-sim)](https://img.shields.io/pypi/pyversions/swift-sim)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[GitHub repository](https://github.com/jhavl/swift) &nbsp;|&nbsp; [Documentation](https://jhavl.github.io/swift) (not yet published)
+[GitHub repository](https://github.com/jhavl/swift) &nbsp;|&nbsp; [Documentation](https://jhavl.github.io/swift)
 
 Swift is a light-weight browser-based animation visualizer which provides:
 
@@ -26,8 +26,6 @@ Built using Python and Javascript, Swift is cross-platform (Linux, MacOS, and Wi
 Swift provides robotics-specific functionality for rapid prototyping of algorithms, research, and education. 
 Through the [Robotics Toolbox for Python](https://github.com/petercorke/robotics-toolbox-python), Swift can visualise over 30 supplied robot models: well-known contemporary robots from Franka-Emika, Kinova, Universal Robotics, Rethink as well as classical robots such as the Puma 560 and the Stanford arm. Swift is under development and will support mobile robots in the future.
 
-
-
 ## What's new in 2.0
 
 Swift's browser frontend has been rebuilt from scratch as modern, dependency-free ES modules (no bundler, no framework, current three.js) — see this release's changelog for the full list. For existing users:
@@ -43,24 +41,8 @@ Swift's browser frontend has been rebuilt from scratch as modern, dependency-fre
 ## Examples
 
 These build up from the simplest possible scene to a fully interactive one. All are in [`examples/`](./examples) and runnable as-is.
+More detailed documentation at [Introduction and tutorial](https://jhavl.github.io/swift/intro.html).
 
-### Render a box
-
-The simplest possible Swift scene: one shape, no motion.
-
-```python
-import spatialgeometry as sg
-from spatialmath import SE3
-from swift import Swift
-
-env = Swift()
-env.launch(realtime=True)
-
-box = sg.Cuboid([0.2, 0.2, 0.2], pose=SE3(0, 0, 0.1), color=[0.2, 0.4, 1.0, 1.0])
-env.add_shape(box)
-
-env.hold()  # keep the browser tab open
-```
 
 ### Render a box, with sliders to move it
 
@@ -94,106 +76,6 @@ while True:
     env.step(0.05)
     time.sleep(0.05)
 ```
-
-### A 2-link arm, built from raw shapes (no robot model)
-
-Before reaching for a full robot model, it's worth seeing what one actually automates. `add_assembly(fk, parts)` takes a pure forward-kinematics function — given the assembly's current `q`, return one world pose per part — plus the parts themselves, and swift builds and owns the handle for you. Here two elongated cuboids stand in for the links of a 2-revolute-joint arm:
-
-```python
-import time
-import numpy as np
-import spatialgeometry as sg
-from spatialmath import SE3
-from swift import Swift, Slider
-
-env = Swift()
-env.launch(realtime=True)
-
-
-class TwoLinkArm:
-    """A pure kinematic model: two links, two revolute joints about z."""
-
-    def __init__(self, L1=0.3, L2=0.25, thickness=0.03):
-        self.L1 = L1
-        self.L2 = L2
-        self.link1 = sg.Cuboid([L1, thickness, thickness], color=[0.8, 0.2, 0.2, 1.0])
-        self.link2 = sg.Cuboid([L2, thickness, thickness], color=[0.2, 0.4, 1.0, 1.0])
-
-    def part_poses(self, q) -> list[SE3]:
-        """World pose of each link, purely as a function of q. Each
-        cuboid's local origin sits at its own proximal (joint) end, so
-        Tx(length / 2) places its centre correctly."""
-        joint1 = SE3.Rz(q[0])
-        joint2 = joint1 * SE3.Tx(self.L1) * SE3.Rz(q[1])
-        return [joint1 * SE3.Tx(self.L1 / 2), joint2 * SE3.Tx(self.L2 / 2)]
-
-
-arm = TwoLinkArm()
-handle = env.add_assembly(
-    arm.part_poses,
-    [arm.link1, arm.link2],
-    q0=[0.0, 0.0],
-    callback=lambda t, values: [values["q1"], values["q2"]],
-)
-
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, label="Joint 1", unit="rad"), name="q1")
-env.add_ui(Slider(lambda v: None, min=-np.pi, max=np.pi, step=0.01, value=0.0, label="Joint 2", unit="rad"), name="q2")
-
-while True:
-    env.step(0.05)
-    time.sleep(0.05)
-```
-
-`TwoLinkArm` is the kinematic model — shareable, and it knows nothing about its own current configuration. `env.add_assembly()` builds the piece that does: an `AssemblyHandle` owning live `q`, exactly what `add_robot()` (below) returns for a real `rtb.Robot` — same class either way. The leap from here to a full robot model is then just: a kinematic model with more than two links, described by `roboticstoolbox` instead of by hand.
-
-### Render a Panda
-
-```python
-import roboticstoolbox as rtb
-from swift import Swift
-
-env = Swift()
-env.launch(realtime=True)
-
-panda = rtb.models.Panda()
-handle = env.add_robot(panda)
-handle.q = panda.qr
-
-env.hold()  # keep the browser tab open
-```
-
-### A box driven by pure kinematics (no interaction)
-
-Not every scene needs sliders — a pose can just as easily be a function of time. Here a box orbits the origin on a circle of radius `3*W` (`W` = box width), while the plane of that circle slowly tilts about the x-axis. Swift owns `t` and calls the callback each step, so there's no manual pose assignment in the loop:
-
-```python
-import time
-import spatialgeometry as sg
-import spatialmath as sm
-from swift import Swift
-
-env = Swift()
-env.launch(realtime=True)
-
-W = 0.1
-box = sg.Cuboid([W, W, W], color=[0.2, 0.4, 1.0, 1.0])
-
-
-def orbit(t, values):
-    return sm.SE3.Rx(t / 10) * sm.SE3.Rz(t) * sm.SE3.Tx(3 * W)
-
-
-env.add_shape(box, callback=orbit)
-
-dt = 0.02
-while True:
-    env.step(dt)
-    time.sleep(dt)
-```
-
-`Tx(3*W)` places the box at the orbit radius; `Rz(t)` spins it around the circle; `Rx(t/10)`, applied last (so in the world frame, after the orbit is computed), tilts the whole orbital plane about x — ten times slower than the orbit itself.
-
-Worth knowing: the ground plane is solid and opaque, so once the tilt carries the box below z=0 it's genuinely hidden underneath the ground from a normal above-ground viewpoint — the same as burying a real box and looking down at the dirt, not a rendering glitch. This particular orbit has no z-offset, so it dips underground for part of every cycle by construction; add a z-offset to `Tx`/wrap it in a translation if you'd rather the whole orbit stayed above the floor.
 
 ### Panda arm follows a target, positioned by sliders
 
@@ -259,29 +141,6 @@ To embed within a Jupyter Notebook cell, use the `browser="notebook"` option whe
 ```python
 env.launch(realtime=True, browser="notebook")
 ```
-
-## Playback controls
-
-Every non-headless session shows a small panel bottom-left of the browser view:
-
-  * a pause/play button (`||`/`▶`) — also bound to the spacebar;
-  * a realtime-speed selector (Max/1x/0.5x/0.25x) — `1x` matches `env.launch(realtime=True)`, `Max` matches the default (`realtime=False`, uncapped). `env.launch(realtime=0.5)` (a specific float, not just `True`/`False`) sets an initial speed directly.
-
-Pressing `s` anywhere in the browser tab (outside a text input) saves a screenshot of the current view, named `swift-YYYY-MM-DD_HH-MM-SS.png` — the same mechanism as `env.screenshot()`, just without a Python round-trip.
-
-## Recording video
-
-Any scene can be recorded straight from Python — call `env.start_recording(...)` around the part you want captured, `env.stop_recording()` when done. The `.webm` file downloads automatically once encoding finishes:
-
-```python
-env.start_recording("my_recording", framerate=20, format="webm")
-
-# ... normal env.step() loop, or any pose changes ...
-
-env.stop_recording()
-```
-
-`format` also accepts `"png"`/`"jpg"` (frame sequences). `"gif"` currently captures real frames but doesn't reliably trigger a download yet — use `"webm"` for now if you need the file to actually save.
 
 ## Installing
 ### Using pip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Swift
 
 ### Status & Project Health
+[![Build Status](https://github.com/jhavl/swift/actions/workflows/python-tests.yml/badge.svg)](https://github.com/jhavl/swift/actions/workflows/python-tests.yml)
 [![PyPI version](https://badge.fury.io/py/swift-sim.svg)](https://badge.fury.io/py/swift-sim)
 [![Downloads](https://static.pepy.tech/badge/swift-sim/month)](https://pepy.tech/projects/swift-sim)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/swift-sim)](https://img.shields.io/pypi/pyversions/swift-sim)
@@ -9,6 +10,8 @@
 ### Ecosystem & Dependencies
 [![A Python Robotics Package](https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/master/.github/svg/py_collection.min.svg)](https://github.com/petercorke/robotics-toolbox-python)
 [![QUT Centre for Robotics Open Source](https://github.com/qcr/qcr.github.io/raw/master/misc/badge.svg)](https://qcr.github.io)
+
+[![powered by three.js](https://img.shields.io/badge/powered_by-three.js-000000?logo=threedotjs&logoColor=white)](https://threejs.org)
 
 [GitHub repository](https://github.com/jhavl/swift) &nbsp;|&nbsp; [Documentation](https://jhavl.github.io/swift/)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/swift-sim)](https://img.shields.io/pypi/pyversions/swift-sim)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[GitHub repository](https://github.com/jhavl/swift) &nbsp;|&nbsp; [Documentation](https://jhavl.github.io/swift)
+[GitHub repository](https://github.com/jhavl/swift) &nbsp;|&nbsp; [Documentation](https://jhavl.github.io/swift/)
 
 Swift is a light-weight browser-based animation visualizer which provides:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Swift
 
-[![A Python Robotics Package](https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/master/.github/svg/py_collection.min.svg)](https://github.com/petercorke/robotics-toolbox-python)
-[![QUT Centre for Robotics Open Source](https://github.com/qcr/qcr.github.io/raw/master/misc/badge.svg)](https://qcr.github.io)
-
 [![PyPI version](https://badge.fury.io/py/swift-sim.svg)](https://badge.fury.io/py/swift-sim)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/swift-sim)](https://img.shields.io/pypi/pyversions/swift-sim)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[![A Python Robotics Package](https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/master/.github/svg/py_collection.min.svg)](https://github.com/petercorke/robotics-toolbox-python)
+[![QUT Centre for Robotics Open Source](https://github.com/qcr/qcr.github.io/raw/master/misc/badge.svg)](https://qcr.github.io)
 
 [GitHub repository](https://github.com/jhavl/swift) &nbsp;|&nbsp; [Documentation](https://jhavl.github.io/swift/)
 


### PR DESCRIPTION
## Summary
- GitHub Pages is already enabled on this repo (`build_type: workflow`, live at https://jhavl.github.io/swift/) but no workflow has ever existed to produce it -- the site currently 404s, with zero deployment history (not even a failed one).
- Adds `.github/workflows/docs.yml`: builds the Sphinx docs (`docs/source` -> `docs/build/html`) and deploys via `actions/deploy-pages`, mirroring the pattern already used in MVTB and bdsim (minus their JupyterLite build step, not applicable here).
- `build` runs on push and PR against `main`/`future`, so a doc-breaking change is caught before merge. `deploy` only runs on push to `main`, matching Pages' configured production source.

## Notes
- `swift-sim`'s own dependency floor (`spatialgeometry>=1.4.0`) has no matching PyPI release yet (only `1.3.0` is published; `main` has the `Path`->`Polyline` rename but hasn't been cut into a release) -- a plain `pip install .[docs]` can't resolve at all. The workflow installs `spatialgeometry` from its own `main` branch first, same workaround `python-tests.yml` already uses.
- `graphviz` is installed as a system dependency for `sphinx.ext.inheritance_diagram`.
- Build uses `sphinx-build -W` (warnings as errors).

## Test plan
- [x] Verified the full install+build sequence end-to-end in a clean, isolated venv (confirmed via `sys.prefix`) against the current `docs/tutorial-intro` content -- `sphinx-build -b html -W` passes with zero warnings.
- [ ] CI will confirm the actual `deploy-pages` step once merged to `main` (can't rehearse a real Pages deploy locally).