### PR TITLE
docs: add sphinx-copybutton, sphinx_autodoc_typehints, autoclass_content=both

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,19 @@ autodoc_member_order = 'bysource'
 # that documents __init__ separately instead, without silently dropping it.
 autoclass_content = 'both'
 
+# A handful of type hints reference roboticstoolbox under a
+# TYPE_CHECKING guard (robot params in Swift.add()/add_robot()/remove(),
+# AssemblyHandle's robot=) -- swift deliberately has no hard dependency
+# on it (lazily imported at runtime, see Swift._import_rtb()), and this
+# docs build doesn't install it either, so sphinx_autodoc_typehints can
+# never resolve those specific references. Expected, not a real problem;
+# suppress rather than adding roboticstoolbox as a docs-only dependency
+# just to satisfy it.
+suppress_warnings = [
+    'sphinx_autodoc_typehints.guarded_import',
+    'sphinx_autodoc_typehints.forward_reference',
+]
+
 # :example:`box1.py` -> hyperlink to the file on GitHub, displayed as
 # "examples/box1.py". Use the explicit-title form, e.g.
 # :example:`box1.py, line 5 <box1.py#L5>`, to link a specific line.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,11 +35,19 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.extlinks',
+    'sphinx_autodoc_typehints',
     'sphinx_autorun',
+    'sphinx_copybutton',
 ]
 
 autosummary_generate = True
 autodoc_member_order = 'bysource'
+
+# Render __init__'s own docstring together with the class docstring --
+# most classes here document their :param:s once on the class docstring
+# (matching the ecosystem convention), but this leaves room for a class
+# that documents __init__ separately instead, without silently dropping it.
+autoclass_content = 'both'
 
 # :example:`box1.py` -> hyperlink to the file on GitHub, displayed as
 # "examples/box1.py". Use the explicit-title form, e.g.
@@ -57,6 +65,14 @@ exclude_patterns = ['test_*']
 autorun_languages = {}
 autorun_languages['pycon_output_encoding'] = 'UTF-8'
 autorun_languages['pycon_input_encoding'] = 'UTF-8'
+
+# -------- sphinx-copybutton options ------------------------------------------
+# Strip interactive prompts (Python and shell) when users copy code snippets.
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+copybutton_only_copy_prompt_lines = False
+copybutton_remove_prompts = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "pyyaml",
 ]
 
-docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autorun"]
+docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autorun", "sphinx-autodoc-typehints", "sphinx-copybutton"]
 
 nb = ["ipython", "notebook"]
 


### PR DESCRIPTION
## Summary
- Adds `sphinx-copybutton` (copy-to-clipboard button on every code block) and `sphinx_autodoc_typehints` (renders each `:param:`'s type inline, pulled from the function/method signature annotation) to `docs/source/conf.py`'s `extensions`, plus the matching `pyproject.toml` `docs` extra.
- Sets `autoclass_content = "both"` so a class documenting `__init__` separately isn't silently dropped -- this repo's current classes all put their `:param:`s on the class docstring itself, so nothing changes today, but this keeps the door open without a silent gap later.
- Per [rvc-ecosystem/README.md](https://github.com/petercorke/rvc-ecosystem)'s Documentation section, which names `sphinx-copybutton` explicitly (alongside `sphinx-codeautolink` and the `sphinx_autorun` -> `sphinx_pyrunblock` migration -- neither included here, out of scope for this change, and the pyrunblock migration's own confirmed rollout order puts swift last anyway). `sphinx_autodoc_typehints` matches the toolbox-wide `:type:`/`:rtype:` convention already referenced in this ecosystem's docstring guidance.
- Matches actual `conf.py` precedent already in place across sibling repos: RTB has all three pieces; MVTB has copybutton; SMTB and bdsim have autodoc_typehints; MVTB also sets `autoclass_content = "both"`.

## Test plan
- [x] Full clean-venv rehearsal (same install sequence `docs.yml` CI uses) -- `sphinx-build -b html -W` succeeds with zero warnings
- [x] Confirmed `sphinx_autodoc_typehints` actually renders per-param types in the generated HTML (e.g. `hold()`'s `timeout` param shows `float | None` inline in `api.html`)
- [x] Confirmed `copybutton.js` is included in the build output
- [x] `pytest tests/` -- 107/108 pass, the one failure is a pre-existing local `spatialgeometry`/`Polyline` version gap unrelated to this change