### PR TITLE
ci: rename workflow to CI for badge consistency

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@
 # in CI ever ran either; only src/swift/public/**'s vendored-asset check
 # existed (see vendor-check.yml).
 
-name: Python tests
+name: CI
 
 on:
   push:


### PR DESCRIPTION
The workflow was named \`Python tests\`, which is what its GitHub Actions badge displays. Renaming it to \`CI\` aligns the badge label with the other repos in the RVC ecosystem, all of which already show a consistent "CI" badge rather than a repo-specific workflow name.

No functional change to the workflow itself.